### PR TITLE
[WIP] Add helpers into evcxr_runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bitflags"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,6 +63,11 @@ dependencies = [
 [[package]]
 name = "byte-tools"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byteorder"
+version = "1.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -184,6 +198,9 @@ dependencies = [
 [[package]]
 name = "evcxr_runtime"
 version = "1.0.0"
+dependencies = [
+ "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "failure"
@@ -428,6 +445,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "safemem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "sha2"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,10 +614,12 @@ dependencies = [
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
 "checksum backtrace-sys 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)" = "bff67d0c06556c0b8e6b5f090f0eac52d950d9dfd1d35ba04e4ca3543eaf6a7e"
+"checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
 "checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
 "checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
+"checksum byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "90492c5858dd7d2e78691cfb89f90d273a2800fc11d98f60786e5d87e2f83781"
 "checksum cc 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "2119ea4867bd2b8ed3aecab467709720b2d55b1bcfe09f772fd68066eaf15275"
 "checksum cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "efe5c877e17a9c717a0bf3613b2709f723202c4e4675cc8f12926ded29bcb17e"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
@@ -639,6 +663,7 @@ dependencies = [
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 "checksum rustyline 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "00b06ac9c8e8e3e83b33d175d39a9f7b6c2c930c82990593719c8e48788ae2d9"
+"checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
 "checksum sig 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6567e29578f9bfade6a5d94a32b9a4256348358d2a3f448cab0021f9a02614a2"
 "checksum syn 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)" = "85fb2f7f9b7a4c8df2c913a852de570efdb40f0d2edd39c8245ad573f5c7fbcc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,7 @@ name = "evcxr_runtime"
 version = "1.0.0"
 dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -321,6 +322,14 @@ dependencies = [
  "error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicase 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -525,6 +534,14 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unicase"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +572,11 @@ dependencies = [
  "cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "void"
@@ -648,6 +670,7 @@ dependencies = [
 "checksum log 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cba860f648db8e6f269df990180c2217f333472b4a6e901e97446858487971e2"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum metadeps 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b122901b3a675fac8cecf68dcb2f0d3036193bc861d1ac0e1c337f7d5254c2"
+"checksum mime 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "4b082692d3f6cf41b453af73839ce3dfc212c4411cbb2441dff80a716e38bd79"
 "checksum nix 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bfb3ddedaa14746434a02041940495bf11325c22f6d36125d3bdd56090d50a79"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
@@ -673,11 +696,13 @@ dependencies = [
 "checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
+"checksum unicase 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d3218ea14b4edcaccfa0df0a64a3792a2c32cc706f1b336e48867f9d3147f90"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363"
+"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"

--- a/evcxr_runtime/Cargo.toml
+++ b/evcxr_runtime/Cargo.toml
@@ -9,3 +9,4 @@ authors = ["David Lattimore <dml@google.com>"]
 
 [dependencies]
 base64 = "0.9.3"
+mime ="0.3.9"

--- a/evcxr_runtime/Cargo.toml
+++ b/evcxr_runtime/Cargo.toml
@@ -8,3 +8,4 @@ readme = "README.md"
 authors = ["David Lattimore <dml@google.com>"]
 
 [dependencies]
+base64 = "0.9.3"

--- a/evcxr_runtime/src/lib.rs
+++ b/evcxr_runtime/src/lib.rs
@@ -27,9 +27,9 @@ pub struct ContentMimeType {
 /// ```
 /// evcxr_runtime::mime_type("text/plain").text("Hello world");
 /// ```
-pub fn mime_type(mime_type: &str) -> ContentMimeType {
+pub fn mime_type<S: Into<String>>(mime_type: S) -> ContentMimeType {
     ContentMimeType {
-        mime_type: mime_type.to_owned(),
+        mime_type: mime_type.into(),
     }
 }
 
@@ -41,10 +41,11 @@ impl ContentMimeType {
     /// evcxr_runtime::mime_type("text/html")
     ///     .text("<span style=\"color: red\">>Hello world</span>");
     /// ```
-    pub fn text(self, text: &str) {
+    pub fn text<S: AsRef<str>>(self, text: S) {
         println!(
             "EVCXR_BEGIN_CONTENT {}\n{}\nEVCXR_END_CONTENT",
-            self.mime_type, text
+            self.mime_type,
+            text.as_ref()
         );
     }
 }
@@ -56,5 +57,10 @@ mod tests {
     #[test]
     fn test_emit_data() {
         mime_type("text/plain").text("Hello world");
+    }
+
+    #[test]
+    fn test_mime_type_accept_string() {
+        mime_type("text/plain".to_owned()).text("Hello world");
     }
 }

--- a/evcxr_runtime/src/lib.rs
+++ b/evcxr_runtime/src/lib.rs
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 extern crate base64;
+extern crate mime;
+
+mod shortcuts;
+
+pub use shortcuts::*;
 
 pub trait Display {
     /// Implementation should emit a representation of itself in one or mime
@@ -54,6 +59,7 @@ impl ContentMimeType {
     /// specified. The content is a binary format (e.g. image/png), the content
     /// should is base64 encoded.
     /// ```
+    /// let buffer: Vec<u8> = vec![];
     /// evcxr_runtime::mime_type("image/png").bytes(&buffer);
     /// ```
     pub fn bytes(self, buffer: &[u8]) {
@@ -64,6 +70,7 @@ impl ContentMimeType {
 #[cfg(test)]
 mod tests {
     use super::mime_type;
+    use mime;
 
     #[test]
     fn test_emit_data() {
@@ -73,5 +80,10 @@ mod tests {
     #[test]
     fn test_mime_type_accept_string() {
         mime_type("text/plain".to_owned()).text("Hello world");
+    }
+
+    #[test]
+    fn test_mime_type_accept_asrefstr() {
+        mime_type(mime::TEXT_PLAIN.as_ref()).text("Hello world");
     }
 }

--- a/evcxr_runtime/src/lib.rs
+++ b/evcxr_runtime/src/lib.rs
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+extern crate base64;
 
 pub trait Display {
     /// Implementation should emit a representation of itself in one or mime
@@ -47,6 +48,16 @@ impl ContentMimeType {
             self.mime_type,
             text.as_ref()
         );
+    }
+
+    /// Emits the supplied content, which should be of the mime type already
+    /// specified. The content is a binary format (e.g. image/png), the content
+    /// should is base64 encoded.
+    /// ```
+    /// evcxr_runtime::mime_type("image/png").bytes(&buffer);
+    /// ```
+    pub fn bytes(self, buffer: &[u8]) {
+        self.text(&base64::encode(buffer))
     }
 }
 

--- a/evcxr_runtime/src/shortcuts.rs
+++ b/evcxr_runtime/src/shortcuts.rs
@@ -1,0 +1,45 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use mime::Mime;
+use mime_type;
+use std::fs;
+use std::io;
+use std::path::Path;
+
+// This module provides a set of helpers / shortcut functions to display content
+
+/// Display the content of a local file.
+///
+/// ```rust
+/// extern crate evcxr_runtime;
+/// extern crate mime;
+/// use evcxr_runtime;
+/// use mime;
+///
+/// evcxr_runtime::display_file("hello.html", mime::TEXT_HTML, true);
+/// evcxr_runtime::display_file("hello.svg", mime::IMAGE_SVG, true);
+/// evcxr_runtime::display_file("hello.png", mime::IMAGE_PNG, false);
+/// ```
+pub fn display_file<P: AsRef<Path>>(path: P, mime: Mime, as_text: bool) -> Result<(), io::Error> {
+    let buffer = fs::read(path)?;
+    let cmt = mime_type(mime.as_ref());
+    if as_text {
+        let text = String::from_utf8_lossy(&buffer);
+        cmt.text(text);
+    } else {
+        cmt.bytes(&buffer);
+    }
+    Ok(())
+}


### PR DESCRIPTION
Hi,

This PR is a try to extend runtime with helpers and shortcuts but I need your feedback about:
1. Do you want to have some helpers / ready to function like [gophernotes/Display.ipynb at master · gopherdata/gophernotes](https://github.com/gopherdata/gophernotes/blob/master/examples/Display.ipynb) as part of the lib. Is evcxr_runtime the right place to add helpers / shortcut to display content from outside (serde_json, images, vega, ndarrays,...) ? or do you prefer
    1. to have them into each own sub-project (enabling rust features is not accessible from jupyter kernel)
    1. to have them into an other project / repository (not under evcxr repository)
    1. other suggestions ?
1. If ok for helpers, to you have some guidelines you would like we follow ?
1. how to play in jupyter/repl with an unpublished crates (wip,...) ?

Tell me before I push other helpers function.

If you like I can move the cherry-pick the first commit into an other PR.