### PR TITLE
Upgrade dependencies

### DIFF
--- a/evcxr/Cargo.toml
+++ b/evcxr/Cargo.toml
@@ -16,19 +16,19 @@ authors = [
 # of which would cause an internal compiler .so file to be dynamically linked,
 # which would necessitate using cargo run or setting LD_LIBRARY_PATH, neither of
 # which we'd want to impose on users.
-syn = { version = "=0.15.1", default-features = false, features = ["parsing", "full", "printing", "clone-impls", "extra-traits"] }
-proc-macro2 = { version = "=0.4.9", default-features = false }
+syn = { version = "=0.15.27", default-features = false, features = ["parsing", "full", "printing", "clone-impls", "extra-traits"] }
+proc-macro2 = { version = "=0.4.27", default-features = false }
 # We have to turn off custom derive for failure as well, since otherwise
 # libproc_macro gets pulled in and we can't run our binary.
-failure = { version = "=0.1.3", default-features = false, features = [ "std" ] }
-tempfile = "=3.0.5"
-libc = "0.2.45"
+failure = { version = "=0.1.5", default-features = false, features = [ "std" ] }
+tempfile = "=3.0.7"
+libc = "0.2.49"
 json = "=0.11.13"
-regex = "=1.1.0"
-lazy_static = "=1.2.0"
-rand = "=0.6.1"
+regex = "=1.1.2"
+lazy_static = "=1.3.0"
+rand = "=0.6.5"
 libloading = "=0.5.0"
-backtrace = "0.3.13"
+backtrace = "0.3.14"
 
 [target.'cfg(unix)'.dependencies]
 sig = "=1.0.0"

--- a/evcxr/Cargo.toml
+++ b/evcxr/Cargo.toml
@@ -19,13 +19,13 @@ syn = { version = "=0.15.1", default-features = false, features = ["parsing", "f
 proc-macro2 = { version = "=0.4.9", default-features = false }
 # We have to turn off custom derive for failure as well, since otherwise
 # libproc_macro gets pulled in and we can't run our binary.
-failure = { version = "=0.1.1", default-features = false, features = [ "std" ] }
-tempfile = "=3.0.3"
-libc = "0.2.40"
+failure = { version = "=0.1.3", default-features = false, features = [ "std" ] }
+tempfile = "=3.0.5"
+libc = "0.2.45"
 json = "=0.11.13"
-regex = "=1.0.2"
-lazy_static = "=1.0.2"
-rand = "=0.5.4"
+regex = "=1.1.0"
+lazy_static = "=1.2.0"
+rand = "=0.6.1"
 libloading = "=0.5.0"
 backtrace = "0.3.13"
 

--- a/evcxr_jupyter/Cargo.toml
+++ b/evcxr_jupyter/Cargo.toml
@@ -13,12 +13,12 @@ authors = [
 [dependencies]
 evcxr = { version = "=0.3.2", path = "../evcxr" }
 json = "=0.11.13"
-failure = { version = "=0.1.3", default-features = false, features = [ "std" ] }
+failure = { version = "=0.1.5", default-features = false, features = [ "std" ] }
 zmq = "=0.8.2"
-uuid = { version = "=0.7.1", features = [ "v4" ] }
+uuid = { version = "=0.7.2", features = [ "v4" ] }
 hmac = "=0.7.0"
 sha2 = "=0.8.0"
 hex = "=0.3.2"
-colored = "=1.6.1"
-dirs = "=1.0.4"
+colored = "=1.7.0"
+dirs = "=1.0.5"
 chrono = "=0.4.6"

--- a/evcxr_jupyter/Cargo.toml
+++ b/evcxr_jupyter/Cargo.toml
@@ -16,8 +16,8 @@ json = "=0.11.13"
 failure = { version = "=0.1.3", default-features = false, features = [ "std" ] }
 zmq = "=0.8.2"
 uuid = { version = "=0.7.1", features = [ "v4" ] }
-hmac = "=0.6.3"
-sha2 = "=0.7.1"
+hmac = "=0.7.0"
+sha2 = "=0.8.0"
 hex = "=0.3.2"
 colored = "=1.6.1"
 dirs = "=1.0.4"

--- a/evcxr_jupyter/Cargo.toml
+++ b/evcxr_jupyter/Cargo.toml
@@ -13,12 +13,12 @@ authors = [
 [dependencies]
 evcxr = { version = "=0.3.2", path = "../evcxr" }
 json = "=0.11.13"
-failure = { version = "=0.1.1", default-features = false, features = [ "std" ] }
+failure = { version = "=0.1.3", default-features = false, features = [ "std" ] }
 zmq = "=0.8.2"
-uuid = { version = "=0.6.5", features = [ "v4" ] }
+uuid = { version = "=0.7.1", features = [ "v4" ] }
 hmac = "=0.6.3"
 sha2 = "=0.7.1"
 hex = "=0.3.2"
-colored = "=1.6.0"
-dirs = "=1.0.2"
+colored = "=1.6.1"
+dirs = "=1.0.4"
 chrono = "=0.4.6"

--- a/evcxr_jupyter/src/jupyter_message.rs
+++ b/evcxr_jupyter/src/jupyter_message.rs
@@ -43,8 +43,9 @@ impl RawMessage {
             jparts,
         };
 
-        if let Some(mac) = &mut connection.mac {
-            raw_message.digest(mac);
+        if let Some(mac_template) = &connection.mac {
+            let mut mac = mac_template.clone();
+            raw_message.digest(&mut mac);
             use hmac::Mac;
             if let Err(error) = mac.verify(&hex::decode(&hmac)?) {
                 bail!("{}", error);
@@ -56,8 +57,9 @@ impl RawMessage {
 
     fn send(self, connection: &mut Connection) -> Result<(), Error> {
         use hmac::Mac;
-        let hmac = if let Some(mac) = &mut connection.mac {
-            self.digest(mac);
+        let hmac = if let Some(mac_template) = &connection.mac {
+            let mut mac = mac_template.clone();
+            self.digest(&mut mac);
             hex::encode(mac.result().code().as_slice())
         } else {
             String::new()

--- a/evcxr_repl/Cargo.toml
+++ b/evcxr_repl/Cargo.toml
@@ -10,8 +10,8 @@ authors = ["David Lattimore <dvdlttmr@google.com>"]
 [dependencies]
 evcxr = { version = "=0.3.2", path = "../evcxr" }
 rustyline = "=1.0.0"
-colored = "=1.6.0"
-dirs = "=1.0.2"
-lazy_static = "=1.0.2"
-failure = { version = "=0.1.1", default-features = false, features = [ "std" ] }
-regex = "=1.0.2"
+colored = "=1.6.1"
+dirs = "=1.0.4"
+lazy_static = "=1.2.0"
+failure = { version = "=0.1.3", default-features = false, features = [ "std" ] }
+regex = "=1.1.0"

--- a/evcxr_repl/Cargo.toml
+++ b/evcxr_repl/Cargo.toml
@@ -10,8 +10,8 @@ authors = ["David Lattimore <dvdlttmr@gmail.com>"]
 [dependencies]
 evcxr = { version = "=0.3.2", path = "../evcxr" }
 rustyline = "=3.0.0"
-colored = "=1.6.1"
-dirs = "=1.0.4"
-lazy_static = "=1.2.0"
-failure = { version = "=0.1.3", default-features = false, features = [ "std" ] }
-regex = "=1.1.0"
+colored = "=1.7.0"
+dirs = "=1.0.5"
+lazy_static = "=1.3.0"
+failure = { version = "=0.1.5", default-features = false, features = [ "std" ] }
+regex = "=1.1.2"

--- a/evcxr_runtime/Cargo.toml
+++ b/evcxr_runtime/Cargo.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 
 [dependencies]
-base64 = { version = "0.10.0", optional = true }
+base64 = { version = "0.10.1", optional = true }
 
 [features]
 bytes = ["base64"]

--- a/runtimes/evcxr_image/Cargo.toml
+++ b/runtimes/evcxr_image/Cargo.toml
@@ -8,5 +8,5 @@ readme = "README.md"
 authors = ["David Lattimore <dml@google.com>"]
 
 [dependencies]
-image = "0.20.1"
+image = "0.21.0"
 evcxr_runtime = {version = "1.1.0", features = [ "bytes" ]}


### PR DESCRIPTION
Maybe connecting a tool like dependabot could help keep / to be alerted when dependencies publish new version.
I never used dependabot with cargo workspace project, but it works well with my rust project.

I didn't try to upgrade syn & proc-macro2