### PR TITLE
improvements in usage of commands like :dep

### DIFF
--- a/evcxr/src/command_context.rs
+++ b/evcxr/src/command_context.rs
@@ -35,15 +35,15 @@ impl CommandContext {
     }
 
     pub fn execute(&mut self, to_run: &str) -> Result<EvalOutputs, Error> {
-        if to_run.is_empty() {
-            return Ok(EvalOutputs::new());
-        }
-        if to_run.starts_with(':') {
-            return self.process_command(to_run);
-        }
         use std::time::Instant;
         let start = Instant::now();
-        let result = self.eval_context.eval(to_run);
+        let result = if to_run.is_empty() {
+            Ok(EvalOutputs::new())
+        } else if to_run.starts_with(':') {
+            self.process_command(to_run)
+        } else {
+            self.eval_context.eval(to_run)
+        };
         let duration = start.elapsed();
         match result {
             Ok(mut m) => {
@@ -68,7 +68,7 @@ impl CommandContext {
         if line == ":internal_debug" {
             let debug_mode = !self.eval_context.debug_mode();
             self.eval_context.set_debug_mode(debug_mode);
-            return text_output(format!("Internals debugging: {}", debug_mode));
+            text_output(format!("Internals debugging: {}", debug_mode))
         } else if line == ":vars" {
             let mut outputs = EvalOutputs::new();
             outputs
@@ -77,19 +77,16 @@ impl CommandContext {
             outputs
                 .content_by_mime_type
                 .insert("text/html".to_owned(), self.vars_as_html());
-            return Ok(outputs);
+            Ok(outputs)
         } else if line == ":clear" {
-            self.eval_context.clear()?;
+            self.eval_context.clear().map(|_| EvalOutputs::new())
         } else if let Some(captures) = ADD_DEP_RE.captures(line) {
-            if let Err(error) = self
+            self
                 .eval_context
                 .add_extern_crate(captures[1].to_owned(), captures[2].to_owned())
-            {
-                bail!("{}", error);
-            }
         } else if line == ":last_compile_dir" {
             if let Some(dir) = &self.eval_context.last_compile_dir() {
-                return text_output(format!("{:?}", dir));
+                text_output(format!("{:?}", dir))
             } else {
                 bail!("Nothing has been compiled yet");
             }
@@ -100,10 +97,10 @@ impl CommandContext {
                 "2"
             };
             self.eval_context.set_opt_level(new_level)?;
-            return text_output(format!("Optimization: {}", self.eval_context.opt_level()));
+            text_output(format!("Optimization: {}", self.eval_context.opt_level()))
         } else if line == ":timing" {
             self.print_timings = !self.print_timings;
-            return text_output(format!("Timing: {}", self.print_timings));
+            text_output(format!("Timing: {}", self.print_timings))
         } else if line == ":explain" {
             if self.last_errors.is_empty() {
                 bail!("No last error to explain");
@@ -116,7 +113,7 @@ impl CommandContext {
                         bail!("Sorry, last error has no explanation");
                     }
                 }
-                return text_output(all_explanations);
+                text_output(all_explanations)
             }
         } else if line == ":last_error_json" {
             let mut errors_out = String::new();
@@ -127,7 +124,7 @@ impl CommandContext {
             }
             bail!(errors_out);
         } else if line == ":help" {
-            return text_output(
+            text_output(
                 ":vars             List bound variables and their types\n\
                  :opt              Toggle optimization\n\
                  :explain          Print explanation of last error\n\
@@ -138,11 +135,10 @@ impl CommandContext {
                  :timing           Toggle printing of how long evaluations take\n\
                  :last_error_json  Print the last compilation error as JSON (for debugging)\n\
                  :internal_debug   Toggle various internal debugging code",
-            );
+            )
         } else {
             bail!("Unrecognised command {}", line);
         }
-        Ok(EvalOutputs::new())
     }
 
     fn vars_as_text(&self) -> String {

--- a/evcxr/src/eval_context.rs
+++ b/evcxr/src/eval_context.rs
@@ -305,11 +305,18 @@ impl EvalContext {
         Ok(())
     }
 
-    pub fn add_extern_crate(&mut self, name: String, config: String) -> Result<(), Error> {
+    pub fn add_extern_crate(&mut self, name: String, config: String) -> Result<EvalOutputs, Error> {
+        let key = name.clone();
         self.state
             .external_deps
-            .insert(name.clone(), ExternalCrate::new(name, config)?);
-        self.eval("").map(|_| ())
+            .insert(key.clone(), ExternalCrate::new(name, config)?);
+        let result = self.eval("");
+        if result.is_err() {
+            self.state
+                .external_deps
+                .remove(&key);
+        }
+        result
     }
 
     pub fn debug_mode(&self) -> bool {

--- a/evcxr_jupyter/src/core.rs
+++ b/evcxr_jupyter/src/core.rs
@@ -190,27 +190,27 @@ impl Server {
                                 "metadata" => HashMap::new(),
                             })
                             .send(&mut *self.iopub.lock().unwrap())?;
-                        if let Some(duration) = output.timing {
-                            // TODO replace by duration.as_millis() when stable
-                            let ms =
-                                duration.as_secs() * 1000 + u64::from(duration.subsec_millis());
-                            let mut data = HashMap::new();
-                            data.insert(
-                                "text/html".into(),
-                                json::from(format!(
-                                    "<span style=\"color: rgba(0,0,0,0.4);\">Took {}ms</span>",
-                                    ms
-                                )),
-                            );
-                            message
-                                .new_message("execute_result")
-                                .with_content(object! {
-                                    "execution_count" => execution_count,
-                                    "data" => data,
-                                    "metadata" => HashMap::new(),
-                                })
-                                .send(&mut *self.iopub.lock().unwrap())?;
-                        }
+                    }
+                    if let Some(duration) = output.timing {
+                        // TODO replace by duration.as_millis() when stable
+                        let ms =
+                            duration.as_secs() * 1000 + u64::from(duration.subsec_millis());
+                        let mut data = HashMap::new();
+                        data.insert(
+                            "text/html".into(),
+                            json::from(format!(
+                                "<span style=\"color: rgba(0,0,0,0.4);\">Took {}ms</span>",
+                                ms
+                            )),
+                        );
+                        message
+                            .new_message("execute_result")
+                            .with_content(object! {
+                                "execution_count" => execution_count,
+                                "data" => data,
+                                "metadata" => HashMap::new(),
+                            })
+                            .send(&mut *self.iopub.lock().unwrap())?;
                     }
                     message.new_reply().with_content(object! {
                         "status" => "ok",


### PR DESCRIPTION
- fullfill timing info for commands (like dep)
- rollback add of external crate if fail to add
- keep the error for failing ‘:dep’

[Imgur](https://i.imgur.com/NZhvlUz.png)

I also would like to allow several commands into a single cell:

```rust
:dep foo=0.1.0
:dep bar=0.2.0
```
and the mix of command and code 

```rust
:dep foo=0.1.0
extern crate foo;
use foo::prelude::*;
```

WDYT ?