### PR TITLE
Fix binder build

### DIFF
--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,1 +1,2 @@
 libzmq3-dev
+cmake


### PR DESCRIPTION
Seems like it's failing because `cmake` is not found. Adding to APT dependencies fixes the problem.

Example binder (working): https://mybinder.org/v2/gh/luizirber/evcxr/fix_binder?filepath=evcxr_jupyter%2Fsamples%2Fevcxr_jupyter_tour.ipynb