### PR TITLE
Specify target-dir via environment variable CARGO_TARGET_DIR

### DIFF
--- a/evcxr/src/module.rs
+++ b/evcxr/src/module.rs
@@ -167,7 +167,7 @@ impl Module {
             .arg("--")
             .arg("-C")
             .arg("prefer-dynamic")
-            .env_remove("CARGO_TARGET_DIR")
+            .env("CARGO_TARGET_DIR", "target")
             .current_dir(self.crate_dir());
         if let Some(sccache) = &self.sccache {
             command.env("RUSTC_WRAPPER", sccache);


### PR DESCRIPTION
I came across the same problem as https://github.com/google/evcxr/issues/69, but https://github.com/google/evcxr/commit/dd41f471bc8953681137ec2596df86bfcf53efab didn't fix it for me. Because I specified the target-dir via `~/.cargo/config`.

I think the best way to solve this problem is to let evcxr specify the `target-dir` by itself, via `CARGO_TARGET_DIR`(it has a higher priority)