### PR TITLE
let output format customizable

### DIFF
--- a/evcxr/src/command_context.rs
+++ b/evcxr/src/command_context.rs
@@ -158,7 +158,7 @@ impl CommandContext {
                 let new_format = if let Some(f) = args { f } else { "{:?}" };
                 self.eval_context.set_output_format(new_format.to_owned());
                 text_output(format!(
-                    "Output foramt: {}",
+                    "Output format: {}",
                     self.eval_context.output_format()
                 ))
             }

--- a/evcxr/src/command_context.rs
+++ b/evcxr/src/command_context.rs
@@ -154,6 +154,14 @@ impl CommandContext {
                 self.eval_context.set_opt_level(new_level)?;
                 text_output(format!("Optimization: {}", self.eval_context.opt_level()))
             }
+            ":fmt" => {
+                let new_format = if let Some(f) = args { f } else { "{:?}" };
+                self.eval_context.set_output_format(new_format.to_owned());
+                text_output(format!(
+                    "Output foramt: {}",
+                    self.eval_context.output_format()
+                ))
+            }
             ":timing" => {
                 self.print_timings = !self.print_timings;
                 text_output(format!("Timing: {}", self.print_timings))
@@ -194,6 +202,7 @@ impl CommandContext {
             ":help" => text_output(
                 ":vars             List bound variables and their types\n\
                  :opt [level]      Toggle/set optimization level\n\
+                 :fmt [format]     Set output formatter (default: {:?}). \n\
                  :explain          Print explanation of last error\n\
                  :clear            Clear all state, keeping compilation cache\n\
                  :dep              Add dependency. e.g. :dep regex = \"1.0\"\n\

--- a/evcxr/src/eval_context.rs
+++ b/evcxr/src/eval_context.rs
@@ -37,6 +37,7 @@ pub struct EvalContext {
     build_num: i32,
     pub(crate) debug_mode: bool,
     opt_level: String,
+    output_format: String,
     module: Module,
     state: ContextState,
     committed_state: ContextState,
@@ -130,6 +131,7 @@ impl EvalContext {
             build_num: 0,
             debug_mode: false,
             opt_level: "2".to_owned(),
+            output_format: "{:?}".to_owned(),
             state: ContextState::default(),
             committed_state: ContextState::default(),
             module,
@@ -247,7 +249,10 @@ impl EvalContext {
                             // If that fails, we try debug format.
                             CodeBlock::new()
                                 .generated(SEND_TEXT_PLAIN_DEF)
-                                .generated("evcxr_send_text_plain(&format!(\"{:?}\",\n")
+                                .generated(&format!(
+                                    "evcxr_send_text_plain(&format!(\"{}\",\n",
+                                    self.output_format
+                                ))
                                 .user_code(stmt_code)
                                 .generated("));"),
                         );
@@ -301,6 +306,13 @@ impl EvalContext {
         }
         self.opt_level = level.to_owned();
         Ok(())
+    }
+    pub fn output_format(&self) -> &str {
+        &self.output_format
+    }
+
+    pub fn set_output_format(&mut self, output_format: String) {
+        self.output_format = output_format;
     }
 
     pub fn set_sccache(&mut self, enabled: bool) -> Result<(), Error> {


### PR DESCRIPTION
It works like this.  CC #67.


```
Welcome to evcxr. For help, type :help
>> :help
:vars             List bound variables and their types
:opt [level]      Toggle/set optimization level
:fmt [format]     Set output formatter (default: {:?}).
:explain          Print explanation of last error
:clear            Clear all state, keeping compilation cache
:dep              Add dependency. e.g. :dep regex = "1.0"
:sccache [0|1]    Set whether to use sccache.
:version          Print Evcxr version
:preserve_vars_on_panic [0|1]  Try to keep vars on panic

Mostly for development / debugging purposes:
:last_compile_dir Print the directory in which we last compiled
:timing           Toggle printing of how long evaluations take
:last_error_json  Print the last compilation error as JSON (for debugging)
:time_passes      Toggle printing of rustc pass times (requires nightly)
:internal_debug   Toggle various internal debugging code

>> #[derive(Debug, Clone, Default)] struct Foo { bar: i32 }
>> Foo::default()
Foo { bar: 0 }
>> :fmt {:#?}
Output foramt: {:#?}

>> Foo::default()
Foo {
    bar: 0,
}
>> :fmt {}
Output foramt: {}

>> Foo::default()
   ^^^^^^^^^^^^^^ `Foo` cannot be formatted with the default formatter
`Foo` doesn't implement `std::fmt::Display`
help: the trait `std::fmt::Display` is not implemented for `Foo`
>> 1
1
>> "hogehoge"
hogehoge
>> :fmt 0x{:x}
Output foramt: 0x{:x}

>> 32
0x20
>>
```