### PR TITLE
Run prelude.rs after init.evcxr if one exists, and support specifying config path via environment.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,6 @@ name = "evcxr_repl"
 version = "0.4.5"
 dependencies = [
  "colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "evcxr 0.4.5",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/evcxr/src/command_context.rs
+++ b/evcxr/src/command_context.rs
@@ -83,8 +83,7 @@ impl CommandContext {
 
     fn load_config(&mut self) -> Result<EvalOutputs, Error> {
         let mut outputs = EvalOutputs::new();
-        if let Some(config_dir) = dirs::config_dir() {
-            let config_dir = config_dir.join("evcxr");
+        if let Some(config_dir) = crate::config_dir() {
             let config_file = config_dir.join("init.evcxr");
             if config_file.exists() {
                 println!("Loading startup commands from {:?}", config_file);

--- a/evcxr/src/lib.rs
+++ b/evcxr/src/lib.rs
@@ -39,3 +39,14 @@ pub use crate::command_context::CommandContext;
 pub use crate::errors::{CompilationError, Error};
 pub use crate::eval_context::{EvalContext, EvalContextOutputs, EvalOutputs};
 pub use crate::runtime::runtime_hook;
+
+/// Return the directory that evcxr tools should use for their configuration.
+///
+/// By default this is the `evcxr` subdirectory of whatever `dirs::config_dir()`
+/// returns, but it can be overridden by the `EVCXR_CONFIG_DIR` environment
+/// variable.
+pub fn config_dir() -> Option<std::path::PathBuf> {
+    std::env::var_os("EVCXR_CONFIG_DIR")
+        .map(std::path::PathBuf::from)
+        .or_else(|| dirs::config_dir().map(|d| d.join("evcxr")))
+}

--- a/evcxr_repl/Cargo.toml
+++ b/evcxr_repl/Cargo.toml
@@ -15,7 +15,6 @@ edition = "2018"
 evcxr = { version = "=0.4.5", path = "../evcxr" }
 rustyline = "5.0.2"
 colored = "1.8.0"
-dirs = "2.0.2"
 lazy_static = "1.3.0"
 failure = { version = "0.1.5", default-features = false, features = [ "std" ] }
 regex = { version = "1.3.1", default-features = false, features = [ "std" ] }

--- a/evcxr_repl/src/bin/evcxr.rs
+++ b/evcxr_repl/src/bin/evcxr.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use dirs;
 use evcxr;
 
 use colored::*;
@@ -141,7 +140,7 @@ fn main() {
 
     let mut editor = Editor::<()>::new();
     let mut opt_history_file = None;
-    let config_dir = dirs::config_dir().map(|h| h.join("evcxr"));
+    let config_dir = evcxr::config_dir();
     if let Some(config_dir) = &config_dir {
         fs::create_dir_all(config_dir).ok();
         let history_file = config_dir.join("history.txt");


### PR DESCRIPTION
Tested manually (both with and without the prelude), since there aren't automated tests for this I could find.