### PR TITLE
Don't default to `lld` on macOS. Fixes #93

### DIFF
--- a/evcxr/src/module.rs
+++ b/evcxr/src/module.rs
@@ -92,7 +92,7 @@ const CRATE_NAME: &str = "ctx";
 
 impl Module {
     pub(crate) fn new(tmpdir: PathBuf) -> Result<Module, Error> {
-        let linker = if which::which("lld").is_ok() {
+        let linker = if !cfg!(target_os = "macos") && which::which("lld").is_ok() {
             "lld".to_owned()
         } else {
             "system".to_owned()

--- a/evcxr/tests/integration_tests.rs
+++ b/evcxr/tests/integration_tests.rs
@@ -558,4 +558,13 @@ fn format() {
     let mut e = new_context();
     assert_eq!(eval!(e, format!("{:x}", 2)), text_plain("\"2\""));
     assert_eq!(eval!(e, format!("{:2x}", 2)), text_plain("\" 2\""));
+    assert_eq!(
+        eval!(e,
+            [1, 2, 3, 4, 5].iter()
+                .map(|v| format!("{:x}", v))
+                .collect::<Vec<_>>()
+                .join(",")
+        ),
+        text_plain("\"1,2,3,4,5\""),
+    );
 }


### PR DESCRIPTION
It also might be worth using a more robust check than the eval of 42 here: https://github.com/google/evcxr/blob/3fa90d0a89a521e4e6388a17f811c2925df0d55e/evcxr/src/eval_context.rs#L146

Edit: I guess I have to tell github here that this fixes #93.