### PR TITLE
Multiline support for evcxr_repl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -37,7 +37,7 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -75,7 +75,7 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -122,7 +122,7 @@ name = "c2-chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -164,7 +164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -176,7 +176,7 @@ name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -197,7 +197,7 @@ name = "colored"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winconsole 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -231,7 +231,7 @@ dependencies = [
  "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -250,7 +250,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -296,7 +296,7 @@ dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_users 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -317,7 +317,7 @@ dependencies = [
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "json 0.11.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -360,10 +360,11 @@ dependencies = [
  "colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "evcxr 0.4.7",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustyline 5.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustyline 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -435,7 +436,7 @@ name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -493,7 +494,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -507,7 +508,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -551,7 +552,7 @@ name = "nix"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -641,7 +642,7 @@ name = "png"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "deflate 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "inflate 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -710,7 +711,7 @@ dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -728,7 +729,7 @@ dependencies = [
  "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -813,7 +814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -826,7 +827,7 @@ dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -864,7 +865,7 @@ dependencies = [
  "crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -910,7 +911,7 @@ name = "remove_dir_all"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -943,18 +944,19 @@ dependencies = [
 
 [[package]]
 name = "rustyline"
-version = "5.0.2"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8parse 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1071,7 +1073,7 @@ dependencies = [
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1100,7 +1102,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1115,7 +1117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.3.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1172,7 +1174,7 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1195,9 +1197,9 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cgmath 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rgb 0.8.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1213,7 +1215,7 @@ name = "zmq"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "zmq-sys 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1240,7 +1242,7 @@ dependencies = [
 "checksum backtrace 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "1371048253fa3bac6704bfd6bbfc922ee9bdcee8881330d40f308b81cc5adc55"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-"checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
+"checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum blake2b_simd 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)" = "bf775a81bb2d464e20ff170ac20316c7b08a43d11dbc72f0f82e8e8d3d6d0499"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
@@ -1283,7 +1285,7 @@ dependencies = [
 "checksum inflate 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1cdb29978cc5797bd8dcc8e5bf7de604891df2a8dc576973d71a281e916db2ff"
 "checksum jpeg-decoder 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "c8b7d43206b34b3f94ea9445174bda196e772049b9bddbc620c9d29b2d20110d"
 "checksum json 0.11.15 (registry+https://github.com/rust-lang/crates.io-index)" = "92c245af8786f6ac35f95ca14feca9119e71339aaab41e878e7cdd655c97e9e5"
-"checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
+"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
@@ -1336,7 +1338,7 @@ dependencies = [
 "checksum rust-argon2 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ca4eaef519b494d1f2848fc602d18816fed808a981aedf4f1f00ceb7c9d32cf"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-"checksum rustyline 5.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f8ee0838a6594169a1c5f4bb9af0fe692cc99691941710a8cc6576395ede804e"
+"checksum rustyline 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de64be8eecbe428b6924f1d8430369a01719fbb182c26fa431ddbb0a95f5315d"
 "checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
@@ -1356,7 +1358,7 @@ dependencies = [
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
-"checksum unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9"
+"checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 "checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
@@ -1366,7 +1368,7 @@ dependencies = [
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum wasi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd5442abcac6525a045cc8c795aedb60da7a2e5e89c7bf18a0d5357849bb23c7"
 "checksum which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
-"checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
+"checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum winconsole 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ef84b96d10db72dd980056666d7f1e7663ce93d82fa33b63e71c966f4cf5032"

--- a/evcxr_repl/Cargo.toml
+++ b/evcxr_repl/Cargo.toml
@@ -13,9 +13,10 @@ edition = "2018"
 
 [dependencies]
 evcxr = { version = "=0.4.7", path = "../evcxr" }
-rustyline = "5.0.2"
+rustyline = "6.0.0"
 colored = "1.8.0"
 lazy_static = "1.3.0"
 failure = { version = "0.1.5", default-features = false, features = [ "std" ] }
 regex = { version = "1.3.1", default-features = false, features = [ "std" ] }
 structopt = "0.3"
+unicode-xid = "0.2"

--- a/evcxr_repl/src/bin/evcxr.rs
+++ b/evcxr_repl/src/bin/evcxr.rs
@@ -22,6 +22,8 @@ use std::io;
 use std::sync::mpsc;
 use structopt::StructOpt;
 
+use evcxr_repl::EvcxrRustylineHelper;
+
 const PROMPT: &str = ">> ";
 
 struct Repl {
@@ -168,8 +170,8 @@ fn main() {
     };
 
     repl.command_context.set_opt_level(&options.opt).ok();
-
-    let mut editor = Editor::<()>::new();
+    let mut editor = Editor::<EvcxrRustylineHelper>::new();
+    editor.set_helper(Some(EvcxrRustylineHelper::default()));
     let mut opt_history_file = None;
     let config_dir = evcxr::config_dir();
     if let Some(config_dir) = &config_dir {
@@ -183,7 +185,7 @@ fn main() {
         let readline = if options.disable_readline {
             readline_direct(&prompt)
         } else {
-            editor.readline(&prompt)
+            editor.readline(PROMPT)
         };
         match readline {
             Ok(line) => {

--- a/evcxr_repl/src/lib.rs
+++ b/evcxr_repl/src/lib.rs
@@ -12,5 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This file exists so that we can give our binary a different name than our crate. Actual code is
-// in bin/evcxr.rs
+mod repl;
+mod scan;
+
+pub use repl::EvcxrRustylineHelper;

--- a/evcxr_repl/src/repl.rs
+++ b/evcxr_repl/src/repl.rs
@@ -1,0 +1,86 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::scan::{validate_source_fragment, FragmentValidity};
+use colored::*;
+use rustyline::{
+    completion::Completer,
+    error::ReadlineError,
+    highlight::Highlighter,
+    hint::Hinter,
+    validate::{ValidationContext, ValidationResult, Validator},
+    Helper,
+};
+use std::borrow::Cow;
+
+pub struct EvcxrRustylineHelper {
+    _priv: (),
+}
+
+impl Default for EvcxrRustylineHelper {
+    fn default() -> Self {
+        Self { _priv: () }
+    }
+}
+
+// Have to implement a bunch of traits as mostly noop...
+
+impl Hinter for EvcxrRustylineHelper {}
+
+impl Completer for EvcxrRustylineHelper {
+    type Candidate = String;
+}
+
+impl Highlighter for EvcxrRustylineHelper {
+    fn highlight_prompt<'b, 's: 'b, 'p: 'b>(
+        &'s self,
+        prompt: &'p str,
+        _default: bool,
+    ) -> Cow<'b, str> {
+        prompt.yellow().to_string().into()
+    }
+}
+
+impl Validator for EvcxrRustylineHelper {
+    fn validate(&self, ctx: &mut ValidationContext<'_>) -> Result<ValidationResult, ReadlineError> {
+        let input = ctx.input();
+        // If a user is hammering on the enter key, lets pass things along to
+        // rustc. This is an escape hatch for the case where *we* know (well,
+        // think) the source is incomplete, but the user doesn't. It also makes
+        // bugs in our code less disasterous.
+        if input.ends_with("\n\n") {
+            return Ok(ValidationResult::Valid(None));
+        }
+        match validate_source_fragment(input) {
+            FragmentValidity::Incomplete => Ok(ValidationResult::Incomplete),
+            FragmentValidity::Invalid => {
+                // Hrm... AFAICT if we return Invalid here, we don't get to run
+                // it. `rustc` is likely to be able to provide a better error
+                // message than us, so...
+                Ok(ValidationResult::Valid(None))
+            }
+            FragmentValidity::Valid => Ok(ValidationResult::Valid(None)),
+        }
+    }
+
+    // We actually work with this on for the most part, but it seems incomplete
+    // in rustyline, so disable it (explicitly). It's unclear how desirable
+    // it is without the ability to e.g. highlight the mismatched bracket or
+    // whatever.
+    fn validate_while_typing(&self) -> bool {
+        false
+    }
+}
+
+impl Helper for EvcxrRustylineHelper {}

--- a/evcxr_repl/src/scan.rs
+++ b/evcxr_repl/src/scan.rs
@@ -1,0 +1,561 @@
+// Copyright 2019 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Sadly, `syn` and friends only handle valid rust -- or at least, `syn` tells
+//! us that an input is invalid, but cannot determine the difference between
+//! inputs that are invalid due to incompleteness and those that are completely
+//! invalid as it stands. (This seems due to the fact that rust's lexical
+//! primitive is not the token, but the token *tree*, which guarantees brackets
+//! are properly nested.
+//!
+//! I looked around and short of writing a parser, nothing on crates.io helps.
+//! So, this is a minimal scanner that attempts to find if input is obviously
+//! unclosed. It handles:
+//!
+//! - Various kinds of brackets: `()`, `[]`, `{}`.
+//!
+//! - Strings, including raw strings with preceeding hashmarks (e.g.
+//!   `r##"foo"##`)
+//!
+//! - Comments, including nested block comments. `/*/` is (properly) not treated
+//!   as a self-closing comment, but the opening of another nesting level.
+//!
+//! - char/byte literals, but not very well, as they're confusing with
+//!   lifetimes. It does just well enough to know that '{' doesn't open a curly
+//!   brace, or to get tripped up by '\u{}'
+//!
+//! It doesn't handle
+//!
+//! - Closure arguments like `|x|`.
+//!
+//! - Generic paremeters like `<` (it's possible we could catch them in the
+//!   turbofish case but probably not worth it).
+//!
+//! - Incomplete expressions/statements which aren't inside some other of a
+//!   nesting, e.g. `foo +` is clearly incomplete, but we don't detect it unless
+//!   it has parens around it.
+//!
+//! In general the goal here was to parse enough not to get confused by cases
+//! that would lead us to think complete input was incomplete. This requires
+//! handling strings, comments, etc, as they are allowed to have a "{" in it
+//! which we'd otherwise think keeps the whole line open.
+//!
+//! Note that from here, it should be possible to use syn to actually parse
+//! things, but that's left alone for now.
+
+use std::iter::Peekable;
+use std::str::CharIndices;
+use unicode_xid::UnicodeXID;
+
+/// Return type for `validate_source_fragment`
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub enum FragmentValidity {
+    /// Note that despite it's name, this really just means "not obviously
+    /// invalid". There are many ways the source might still be invalid or
+    /// incomplete that we fail to detect, but that's a limitation of the fact
+    /// that we don't actually understand the source beyond purely lexical
+    /// information.
+    Valid,
+    /// This generally means that we see a problem, and believe that, as it
+    /// currently stands, additional input is not going to fix the problem. For
+    /// example, mismatched braces and the like.
+    ///
+    /// At the moment we just send your input to rustc right away if we see
+    /// this, but the UX is a bit awkward here, as it can mean we send the input
+    /// off before you expect, but this seems likely to require changes to
+    /// rustyline.
+    Invalid,
+    /// The input seems good enough, but incomplete. There's some sort of
+    /// obvious indication the source is incomplete: an unclosed string quote,
+    /// some sort of bracket, etc. It's pretty important that we avoid saying
+    /// the source is incomplete when it's actually complete (as this would
+    /// prevent the user from submitting.
+    Incomplete,
+}
+
+/// Determine if a piece of source is valid, invalid, or merely incomplete. This
+/// is approximate, see the module comment for details. The intent is for
+/// - Incomplete to be used to mean "keep a multiline block going"
+/// - Valid to mean "finishing a multiline block is allowed"
+/// - and Invalid to mean something fuzzy like "wait for the user to finish the
+///   current line, then send to rustc and give an error".
+///     - Ideally, we'd indicate some kinds of invalidity to the user before
+///       submitting -- it can be pretty surprising to be in the middle of a
+///       function, add one-too-many closing parens to a nested function call,
+///       and have the whole (obviously incomplete) source get sent off to the
+///       compiler.
+pub fn validate_source_fragment(source: &str) -> FragmentValidity {
+    use Bracket::*;
+    let mut stack: Vec<Bracket> = vec![];
+
+    let mut input = source.char_indices().peekable();
+    while let Some((i, c)) = input.next() {
+        match c {
+            // Possibly a comment.
+            '/' => match input.peek() {
+                Some((_, '/')) => {
+                    eat_comment_line(&mut input);
+                }
+                Some((_, '*')) => {
+                    input.next();
+                    if !eat_comment_block(&mut input) {
+                        return FragmentValidity::Incomplete;
+                    }
+                }
+                _ => {}
+            },
+            '(' => stack.push(Round),
+            '[' => stack.push(Square),
+            '{' => stack.push(Curly),
+            ')' | ']' | '}' => {
+                match (stack.pop(), c) {
+                    (Some(Round), ')') | (Some(Square), ']') | (Some(Curly), '}') => {
+                        // good.
+                    }
+                    _ => {
+                        // Either the bracket stack was empty or mismatched. In
+                        // the future, we should distinguish between these, and
+                        // for a bracket mismatch, highlight it in the prompt
+                        // somehow. I think this will require changes to
+                        // `rustyline`, though.
+                        return FragmentValidity::Invalid;
+                    }
+                }
+            }
+            '\'' => {
+                // A character or a lifetime.
+                match eat_char(&mut input) {
+                    Some(EatCharRes::SawInvalid) => {
+                        return FragmentValidity::Invalid;
+                    }
+                    Some(_) => {
+                        // Saw something valid. These two cases are currently
+                        // just to verify eat_char behaves as expected in tests
+                    }
+                    None => {
+                        return FragmentValidity::Incomplete;
+                    }
+                }
+            }
+            // Start of a string.
+            '\"' => {
+                if let Some(sane_start) = check_raw_str(source, i) {
+                    if !eat_string(&mut input, sane_start) {
+                        return FragmentValidity::Incomplete;
+                    }
+                } else {
+                    return FragmentValidity::Invalid;
+                }
+            }
+            _ => {}
+        }
+    }
+    // Seems good to me if we get here!
+    if stack.is_empty() {
+        FragmentValidity::Valid
+    } else {
+        FragmentValidity::Incomplete
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Debug)]
+enum StrKind {
+    /// Normal string. Closed on first ", but a backslash can escape a single
+    /// quote.
+    Normal,
+    /// Raw string. Closed after we see a " followed by the right num of
+    /// backslashes,
+    RawStr { hashes: usize },
+}
+
+/// `quote_idx` should point at the byte index of the starting double-quote of a
+/// string.
+///
+/// Returns Some(depth) where depth is how many #### the string has (e.g. how
+/// after seeing a closing \", do we need to think we're done), or None if
+/// something looks dodgy.
+///
+/// information that we should hopefully know whether or not the string closed,
+/// or None if it seems like an invalid string, in which case
+fn check_raw_str(s: &str, quote_idx: usize) -> Option<StrKind> {
+    use StrKind::*;
+    debug_assert_eq!(s.as_bytes()[quote_idx], b'"');
+    let sb = s.as_bytes();
+    let index_back =
+        |idx: usize| -> Option<u8> { quote_idx.checked_sub(idx).and_then(|i| sb.get(i).copied()) };
+    match index_back(1) {
+        // Raw string, no hashes.
+        Some(b'r') => Some(RawStr { hashes: 0 }),
+        Some(b'#') => {
+            let mut count = 1;
+            loop {
+                let c = index_back(1 + count);
+                match c {
+                    Some(b'#') => count += 1,
+                    Some(b'r') => break,
+                    // Syntax error?
+                    _ => return None,
+                }
+            }
+            Some(RawStr { hashes: count })
+        }
+        _ => Some(Normal),
+    }
+}
+
+/// Expects to be called after `iter` has consumed the starting \". Returns true
+/// if the string was closed.
+fn eat_string(iter: &mut Peekable<CharIndices<'_>>, kind: StrKind) -> bool {
+    let (closing_hashmarks, escapes_allowed) = match kind {
+        StrKind::Normal => (0, true),
+        StrKind::RawStr { hashes } => (hashes, false),
+    };
+
+    while let Some((_, c)) = iter.next() {
+        match c {
+            '"' => {
+                if closing_hashmarks == 0 {
+                    return true;
+                }
+                let mut seen = 0;
+                while let Some((_, '#')) = iter.peek() {
+                    iter.next();
+                    seen += 1;
+                    if seen == closing_hashmarks {
+                        return true;
+                    }
+                }
+            }
+            '\\' if escapes_allowed => {
+                // Consume whatever is next -- but whatever it was doesn't
+                // really matter to us.
+                iter.next();
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+/// Expects to be called after `iter` has *fully consumed* the initial `//`.
+///
+/// Consumes the entire comment, including the `\n` and returns true, or returns
+/// false if we exhausted `iter` before finding a `\n`.
+fn eat_comment_line<I: Iterator<Item = (usize, char)>>(iter: &mut I) {
+    while let Some((_, c)) = iter.next() {
+        if c == '\n' {
+            break;
+        }
+    }
+}
+
+/// Expects to be called after `iter` has *fully consumed* the initial `/*`
+/// already. returns `true` if it scanned a fully valid nesting, and false
+/// otherwise.
+fn eat_comment_block(iter: &mut Peekable<CharIndices<'_>>) -> bool {
+    let mut depth = 1;
+    while depth != 0 {
+        let c = if let Some(next) = iter.next() {
+            next.1
+        } else {
+            return false;
+        };
+        match c {
+            '/' => {
+                if let Some((_, '*')) = iter.peek() {
+                    iter.next();
+                    depth += 1;
+                }
+            }
+            '*' => {
+                if let Some((_, '/')) = iter.peek() {
+                    iter.next();
+                    depth -= 1;
+                }
+            }
+            _ => {}
+        }
+    }
+    true
+}
+
+/// Return value of `eat_char`.
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum EatCharRes {
+    AteChar,
+    SawLifetime,
+    SawInvalid,
+}
+
+/// This is kinda hacky, but with a simple scanner like ours, it's hard to tell
+/// lifetimes and char's apart.
+///
+/// Well, sort of. It's pretty easy to recognize chars in *valid* syntax, but we
+/// need to fail gracefully in the case that a user types some invalid syntax.
+/// It's not okay if a user types `foo('a ')` and we think the `(` never got
+/// closed.
+///
+/// This function either:
+/// - sees a char literal, and advances the iterator past it, returning
+///   `Some(AteChar)`.
+/// - sees something that could be a lifetime, and returns `Some(SawLifetime)`.
+/// - sees something it knows is invalid, and returns `Some(SawInvalid)`.
+/// - hits the end of the string, and returns None. This is `None` rather than
+///   another `EatCharRes` case so that we can use `?`.
+///
+/// Note that the caller (`eat_char`) enforces consistent behavior WRT `input`
+/// position in the cases where we don't consume a character.
+fn do_eat_char(input: &mut Peekable<CharIndices<'_>>) -> Option<EatCharRes> {
+    let (_, nextc) = input.next()?;
+    if nextc == '\n' || nextc == '\r' || nextc == '\t' {
+        // these are illegal inside a char literal, according to
+        // https://doc.rust-lang.org/reference/tokens.html#character-literals
+        return Some(EatCharRes::SawInvalid);
+    }
+
+    if nextc == '\\' {
+        // Eating an escape sequence. Eat the character which was escaped.
+        // Critically, this might be a single quote, which would confuse the
+        // test in the loop below.
+        let (_, c) = input.next()?;
+        // Chars which are allowed to appear after a backslash in a char escape,
+        // according to the same link as above.
+        let esc = ['\\', '\'', '"', 'x', 'u', 'n', 't', 'r', '0'];
+        if !esc.contains(&c) {
+            return Some(EatCharRes::SawInvalid);
+        }
+        // At this point, we're reasonably confident it's an escaped char literal.
+        // Hope for the best, and read until we see a closing quote or something
+        // that definitely doesn't belong. This should probably be made smarter,
+        // since the actual syntax for the escape sequences is not that bad.
+        while let Some((_, c)) = input.next() {
+            if c == '\'' {
+                return Some(EatCharRes::AteChar);
+            }
+            // Sanity check for a newline, which probably indicates an unclosed
+            // quote.
+            if c == '\n' {
+                return Some(EatCharRes::SawInvalid);
+            }
+        }
+        // Hit end of string.
+        None
+    } else {
+        // Not an escape sequence
+        let could_be_lifetime = UnicodeXID::is_xid_start(nextc);
+        // The first char inside the quote was not a backslash, so it's either
+        // some sort of lifetime, or a char literal. If it's a char literal, the
+        // very *next* thing should be a closing quote...
+        let (_, maybe_end) = input.next()?;
+
+        Some(if maybe_end == '\'' {
+            EatCharRes::AteChar
+        } else if could_be_lifetime {
+            // This is needed to defend against cases like `foo('a ')`. We want
+            // to catch that this is invalid, because missing the `)` would be
+            // bad -- we might think `(` never got closed.
+            EatCharRes::SawLifetime
+        } else {
+            // Couldn't be a lifetime, but we didn't get a closing quote where
+            // we needed, so it must be invalid.
+            EatCharRes::SawInvalid
+        })
+    }
+}
+
+/// This should be right called after `input` reads a `'`. See `do_eat_char` for
+/// the explanation of what it does, this wrapper just exists to ensure that
+/// function leaves `input` in a consistent place in cases other than "ate the
+/// character" and "hit end of string", by making sure it doesn't modify the
+/// iterator except in those cases.
+///
+/// This is to keep things consistent/testable and avoid having to say "if we
+/// didn't scan a char, the iterator is left wherever it was when we became
+/// convinced it couldn't be one", and not because correctness current depends
+/// on the behavior.
+///
+/// Worth noting that it's likely this behavior makes no sense for the
+/// SawInvalid case -- in the future we probably want to have that advance past
+/// the invalid part.
+fn eat_char(input: &mut Peekable<CharIndices<'_>>) -> Option<EatCharRes> {
+    let mut scratch_input = input.clone();
+    let res = do_eat_char(&mut scratch_input);
+    if let Some(EatCharRes::AteChar) | None = res {
+        *input = scratch_input;
+    }
+    res
+}
+
+#[derive(Copy, Clone, PartialEq)]
+enum Bracket {
+    Round,
+    Square,
+    Curly,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    // Left arg is `None` if the nesting is invalid, or Some(remaining_str) if valid.
+    // note that for leaving it with no more chars we use "".
+    fn block_comment_test(s: &str, remaining: impl Into<Option<&'static str>>) {
+        let mut i = s.char_indices().peekable();
+        assert!(i.next().unwrap().1 == '/', "{}", s);
+        assert!(i.next().unwrap().1 == '*', "{}", s);
+        let good = eat_comment_block(&mut i);
+        if let Some(want) = remaining.into() {
+            let i = i.next().map_or(s.len(), |t| t.0);
+            assert_eq!(&s[i..], want, "{}", s);
+        } else {
+            assert!(!good, "{}", s);
+        }
+    }
+    fn line_comment_test(s: &str, remaining: &str) {
+        // It doesn't care about peekable, but we *are* going to give it one, so
+        // do so in the test in case somehow it matters.
+        let mut i = s.char_indices().peekable();
+        eat_comment_line(&mut i);
+        let next_idx = i.next().map_or(s.len(), |(i, _)| i);
+        assert_eq!(&s[next_idx..], remaining);
+    }
+    #[test]
+    fn test_comment_scan() {
+        block_comment_test("/* */", "");
+        block_comment_test("/* */ abcd", " abcd");
+        block_comment_test("/* /*/ */ */ 123", " 123");
+        block_comment_test("/*/", None);
+        block_comment_test("/* /* /* */ */", None);
+        block_comment_test("/* /* /* */ */ */", "");
+        block_comment_test("/* /* /*/ */ */ */", "");
+
+        line_comment_test("// foo\n bar", " bar");
+        line_comment_test("// foo", "");
+        // Test some degenerate cases, specifically if we ever call it with
+        // different args, it should still behave properly.
+        line_comment_test("\n", "");
+        line_comment_test("/\n", "");
+        line_comment_test("/", "");
+        line_comment_test("\n bar", " bar");
+        line_comment_test("/\n bar", " bar");
+    }
+
+    #[test]
+    fn test_string_scan() {
+        use StrKind::*;
+        assert_eq!(check_raw_str(r#" "" "#, 1), Some(Normal));
+        assert_eq!(check_raw_str(r#" r#"" "#, 3), Some(RawStr { hashes: 1 }));
+        assert_eq!(check_raw_str(r#" r##"" "#, 4), Some(RawStr { hashes: 2 }));
+        assert_eq!(check_raw_str(r#""" "#, 0), Some(Normal));
+        // Error cases.
+        assert_eq!(check_raw_str(r#" ##"" "#, 3), None);
+        assert_eq!(check_raw_str(r#"##"" "#, 2), None);
+    }
+
+    fn char_scan_test(test: &str, after: &str, res: Option<EatCharRes>) {
+        let mut i = test.char_indices().peekable();
+
+        assert_eq!(i.next().unwrap(), (0, '\''));
+        let actual = eat_char(&mut i);
+        // Make sure we ended up where we said we would.
+        let next_idx = i.next().map_or(test.len(), |t| t.0);
+        assert_eq!(&test[next_idx..], after);
+        assert_eq!(actual, res, "bad result for {}", test);
+    }
+    #[test]
+    fn test_char_scan() {
+        use EatCharRes::*;
+        char_scan_test("'static", "static", Some(SawLifetime));
+        char_scan_test("'s'abc", "abc", Some(AteChar));
+        char_scan_test("'a ", "a ", Some(SawLifetime));
+        char_scan_test("'\\\\' foo", " foo", Some(AteChar));
+        char_scan_test("'\\\'' foo", " foo", Some(AteChar));
+        char_scan_test("'\\u{1234}' foo", " foo", Some(AteChar));
+        char_scan_test("'ü' abc", " abc", Some(AteChar));
+        char_scan_test("'😀'foo", "foo", Some(AteChar));
+        char_scan_test("'😀", "", None);
+
+        char_scan_test("'\\\\'", "", Some(AteChar));
+        char_scan_test("'\\\''", "", Some(AteChar));
+        char_scan_test("'\\u{1234}", "", None);
+        char_scan_test("'\\n'", "", Some(AteChar));
+
+        char_scan_test("'a", "", None);
+        char_scan_test("'", "", None);
+        char_scan_test("'\n'", "\n'", Some(SawInvalid));
+        char_scan_test("') ", ") ", Some(SawInvalid));
+        char_scan_test("'\\\n ", "\\\n ", Some(SawInvalid));
+        char_scan_test("'\\u{1234} \n\n'", "\\u{1234} \n\n'", Some(SawInvalid));
+    }
+
+    fn test_validity(frag: &str, expect: FragmentValidity) {
+        assert_eq!(
+            validate_source_fragment(frag),
+            expect,
+            "for source fragment: `{}`",
+            frag
+        );
+        if expect == FragmentValidity::Invalid {
+            return;
+        }
+        // Ensure that for valid/incomplete source strings, all prefixes are
+        // either valid or incomplete. It seems like in the finished version of
+        // the rustyline validation features we don't get called except on
+        // newlines, so this is a bit more aggressive than we actually need.
+        // Still, at the moment it doesn't hurt.
+        for (i, _) in frag.char_indices() {
+            assert_ne!(
+                validate_source_fragment(&frag[..i]),
+                FragmentValidity::Invalid,
+                "validating {:?}, as substring of:\n`{}`",
+                &frag[..i],
+                frag,
+            );
+        }
+    }
+    #[test]
+    fn test_valid_source() {
+        let valid = |f: &str| {
+            test_validity(f, FragmentValidity::Valid);
+        };
+        let partial = |f: &str| {
+            test_validity(f, FragmentValidity::Incomplete);
+        };
+        let invalid = |f: &str| {
+            test_validity(f, FragmentValidity::Invalid);
+        };
+        valid("let valid = |f: &str| { test_validity(f, FragmentValidity::Valid); };");
+        valid(stringify! {
+            foo<'static>('\'', 1, r#"##"#);
+        });
+        invalid("[test)");
+        invalid("test)");
+        invalid("'['test]");
+        partial("fn test_valid_source() {");
+
+        partial("\"test 123");
+        partial("r#\"test 123\"");
+
+        valid("r##\"test 123\"# \"##.len()");
+
+        valid("// 123 /*");
+        valid("/* 123 /*\n// */ */");
+        // Valid, as 'a might start a lifetime
+        valid("'a\n");
+        // Invalid, as '3 could not.
+        invalid("'3\n");
+        // This is invalid, but the important thing is that we don't say
+        // incomplete.
+        invalid("foo('a ')\n");
+    }
+}


### PR DESCRIPTION
Fixes #4

This is something I've wanted for a while, and have been poking at off and on.

It ended up being a lot more involved than I had hoped. This is because essentially nothing that parses or scans rust seems to handle unmatched brackets at all, since they all operate on token trees, which must be well formed. I even asked wg-grammar channel on discord, and basically got told that I was going to have to go my own way, or use something like tree-sitter (which would only solve half the problem (lexing), requires taking a C dependency, and then either writing a tree-sitter grammar for rust or vendoring one from one of the text editors...


I considered the naive solution of just scanning for parens/brackets and ignoring anything else, but in practice it's pretty annoying: it's not really okay for the repl to see a `"("` and then never send your input since it thinks it's invalid -- so you need to at least lex the input well enough to notice strings/chars/comments, so that's what I did.

Unfortunately, even just this much is pretty involved, as rust's syntax for these is surprisingly tricky: Block comments can nest, chars are hard to distinguish from lifetimes, and it has `raw` strings.

That said, it works well in practice, has lots of comments, and pretty good test coverage, so hopefully it's not too controversial.

I'd also like to improve the repl more in the near future -- rustyline seems to have support for a few more things that would be useful, and it's possible we can use `syn` to handle many of the cases this misses (in particular detecting missing semicolons on stuff like `let x = 3` probably requires syn in order to be robust), but for now this patch was already pretty huge, so I left it as is.

Note: I've only tested this manually on macos at the moment, but have access to other platforms and will try to get around to it soon.