### PR TITLE
Update rustyline and highlighter logic

### DIFF
--- a/evcxr_repl/Cargo.toml
+++ b/evcxr_repl/Cargo.toml
@@ -13,7 +13,8 @@ edition = "2018"
 
 [dependencies]
 evcxr = { version = "=0.5.0", path = "../evcxr" }
-rustyline = "6.0.0"
+rustyline = { git = "https://github.com/kkawakam/rustyline" }
+#rustyline = "6.0.0"
 colored = "1.8.0"
 lazy_static = "1.3.0"
 failure = { version = "0.1.5", default-features = false, features = [ "std" ] }


### PR DESCRIPTION
This will require a new release of rustyline but it would be a good point to start discuss what would make the repl more user friendly when doing multi line work.

Currently this

- changes the prompt to `.. ` when doing a multi line input
- highlights the previous bracket in blue after typing the closing match

This is a little rough around the edges and am not sure if `EvcxrRustylineHelper` is where we want to store the prompt configuration ?