### PR TITLE
Added explicit image import to sample; adapted code to match recent version.

### DIFF
--- a/evcxr_jupyter/samples/evcxr_jupyter_tour.ipynb
+++ b/evcxr_jupyter/samples/evcxr_jupyter_tour.ipynb
@@ -331,6 +331,15 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    ":dep image = \"0.23\""
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
    "outputs": [],
@@ -342,7 +351,7 @@
     "    fn evcxr_display(&self) {\n",
     "        let mut buffer = Vec::new();\n",
     "        image::png::PNGEncoder::new(&mut buffer).encode(&**self, self.width(), self.height(),\n",
-    "            image::ColorType::RGB(8)).unwrap();\n",
+    "            image::ColorType::Rgb8).unwrap();\n",
     "        let img = base64::encode(&buffer);\n",
     "        println!(\"EVCXR_BEGIN_CONTENT image/png\\n{}\\nEVCXR_END_CONTENT\", img);        \n",
     "    }\n",
@@ -351,7 +360,7 @@
     "    fn evcxr_display(&self) {\n",
     "        let mut buffer = Vec::new();\n",
     "        image::png::PNGEncoder::new(&mut buffer).encode(&**self, self.width(), self.height(),\n",
-    "            image::ColorType::Gray(8)).unwrap();\n",
+    "            image::ColorType::L8).unwrap();\n",
     "        let img = base64::encode(&buffer);\n",
     "        println!(\"EVCXR_BEGIN_CONTENT image/png\\n{}\\nEVCXR_END_CONTENT\", img);        \n",
     "    }\n",


### PR DESCRIPTION
The code in the binder sample which was using the image crate was not working anymore, since the API changed. I added an explicit dep statement and fixed the code according to the current version.