### PR TITLE
display_errors() does not work properly with multi line inputs.

### DIFF
--- a/evcxr_repl/src/bin/evcxr.rs
+++ b/evcxr_repl/src/bin/evcxr.rs
@@ -105,13 +105,12 @@ impl Repl {
                 for spanned_message in error.spanned_messages() {
                     if let Some(span) = &spanned_message.span {
                         if source_lines.len() > 1 {
-                            // print the lines - for multi line source code
+                            // for multi line source code, print the lines
                             if last_span_lines != &spanned_message.lines {
                                 for line in &spanned_message.lines {
                                     println!("{}", line);
                                 }
                             }
-                            // last_span_lines = spanned_message.lines.clone();
                             last_span_lines = &spanned_message.lines;
                         } else {
                             let prompt_spaces : String = (0..PROMPT.len()).map(|_| " ").collect();

--- a/evcxr_repl/src/bin/evcxr.rs
+++ b/evcxr_repl/src/bin/evcxr.rs
@@ -113,16 +113,11 @@ impl Repl {
                             }
                             last_span_lines = &spanned_message.lines;
                         } else {
-                            let prompt_spaces : String = (0..PROMPT.len()).map(|_| " ").collect();
-                            print!("{}", prompt_spaces);
+                            print!("{}", " ".repeat(PROMPT.len()));
                         }
-                        let spaces : String = (1..span.start_column).map(|_| " ").collect();
-                        print!("{}", spaces);
+                        print!("{}", " ".repeat(span.start_column - 1));
 
-                        let mut carrots = String::new();
-                        for _ in span.start_column..span.end_column {
-                            carrots.push('^');
-                        }
+                        let carrots = "^".repeat(span.end_column - span.start_column);
                         print!("{}", carrots.bright_red());
                         println!(" {}", spanned_message.label.bright_blue());
                     } else {


### PR DESCRIPTION
The right side is master, the left side is this PR's changes.

![image](https://user-images.githubusercontent.com/2920178/88267920-2440a100-cd04-11ea-9d60-7c82bebb7890.png)

For multi-line inputs, printing the span lines, makes it more readable - I think :)