### PR TITLE
Add build-essential as installation requirement

### DIFF
--- a/evcxr_jupyter/README.md
+++ b/evcxr_jupyter/README.md
@@ -13,7 +13,7 @@ instructions](https://www.rust-lang.org/tools/install).
 
 ```sh
 rustup component add rust-src
-sudo apt install jupyter-notebook cmake
+sudo apt install jupyter-notebook cmake build-essential
 cargo install evcxr_jupyter
 evcxr_jupyter --install
 ```


### PR DESCRIPTION
Without the Ubuntu build-essential package, zmq-sys will not be able to compile as it can not find `/usr/bin/cc` or whatever CMAKE_C_COMPILER is supposed to be set to.

Most developers will have build-essential already installed, but when setting this up on a new machine it might be missing.