### PR TITLE
Absolute paths in dependency validation

### DIFF
--- a/evcxr/src/eval_context.rs
+++ b/evcxr/src/eval_context.rs
@@ -1145,10 +1145,11 @@ impl ContextState {
                 return Ok(());
             }
         }
-        crate::cargo_metadata::validate_dep(dep, dep_config, &self.config)?;
+        let external = ExternalCrate::new(dep.to_owned(), dep_config.to_owned())?;
+        crate::cargo_metadata::validate_dep(&external.name, &external.config, &self.config)?;
         self.external_deps.insert(
             dep.to_owned(),
-            ExternalCrate::new(dep.to_owned(), dep_config.to_owned())?,
+            external
         );
         Ok(())
     }


### PR DESCRIPTION
Fixes the problems described in #161 to make sure local packages can be identified by relative paths