### PR TITLE
Allow optionally (on by default) using mimalloc as a global allocator in binaries.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,6 +558,7 @@ dependencies = [
  "hex",
  "hmac",
  "json",
+ "mimalloc",
  "sha2",
  "unicode-segmentation",
  "uuid",
@@ -570,6 +571,7 @@ version = "0.9.0"
 dependencies = [
  "colored",
  "evcxr",
+ "mimalloc",
  "once_cell",
  "regex",
  "rustyline",
@@ -850,6 +852,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2396cf99d2f58611cd69f0efeee4af3d2e2c7b61bed433515029163aa567e65c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,6 +927,15 @@ dependencies = [
  "error-chain",
  "pkg-config",
  "toml",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7c6b11afd1e5e689ac96b6d18b1fc763398fe3d7eed99e8773426bc2033dfb"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]

--- a/evcxr_jupyter/Cargo.toml
+++ b/evcxr_jupyter/Cargo.toml
@@ -21,7 +21,8 @@ colored = "2.0.0"
 dirs = "3.0.1"
 chrono = "0.4.19"
 unicode-segmentation = "1.7.1"
+mimalloc = { version = "0.1", default-features = false, optional = true }
 
 [features]
-default = ["vendored-zmq"]
+default = ["vendored-zmq", "mimalloc"]
 vendored-zmq = ["zmq/vendored"]

--- a/evcxr_jupyter/src/main.rs
+++ b/evcxr_jupyter/src/main.rs
@@ -53,3 +53,7 @@ fn main() -> Result<()> {
     println!("To uninstall, run:\n  {} --uninstall", bin);
     Ok(())
 }
+
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static MIMALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;

--- a/evcxr_repl/Cargo.toml
+++ b/evcxr_repl/Cargo.toml
@@ -8,6 +8,9 @@ readme = "README.md"
 authors = ["The Evcxr Authors"]
 edition = "2018"
 
+[features]
+default = ["mimalloc"]
+
 [dependencies]
 evcxr = { version = "=0.9.0", path = "../evcxr" }
 rustyline = "7.1.0"
@@ -17,3 +20,4 @@ regex = { version = "1.4.1", default-features = false, features = [ "std" ] }
 structopt = "0.3"
 unicode-xid = "0.2"
 unicode-segmentation = "1.7.1"
+mimalloc = { version = "0.1", default-features = false, optional = true }

--- a/evcxr_repl/src/bin/evcxr.rs
+++ b/evcxr_repl/src/bin/evcxr.rs
@@ -299,6 +299,10 @@ fn parse_edit_mode(src: &str) -> Result<EditMode, &str> {
     Ok(mode)
 }
 
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static MIMALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 #[cfg(test)]
 mod tests {
     use super::character_column_to_grapheme_number;


### PR DESCRIPTION
On my macOS machine, this brings down the startup time of `evcxr_repl` (mostly spent initializing rust-analyzer) from ~3.4-3.8s to ~1.5-1.8s(!!!).

I'd expect other OSes to be less dramatic (userspace allocation on macOS has... some issues), but mimalloc is insanely fast, and this seems to help a great deal.

I don't use jupyter, and so I am just assuming this is worth doing for evcxr_jupyter too — I can't really say how much this helps. I figure there's likely no reason not to do it for both of the binary crates. I set it as optional, in case someone hits issues and needs to disable it — weird platform issues, for example.

I also disabled the default features, since they're security checks (guard pages, heap verification, and the like). My thoughts on that are https://github.com/purpleprotocol/mimalloc_rust/issues/39 — We're already using a memory safe language, so IMO that stuff should be opt-in. Oh well, easy enough for us to turn off, it's not like evcxr has a ton of pointer manipulation or anything anyway.