### PR TITLE
Add support for linking with mold

### DIFF
--- a/COMMON.md
+++ b/COMMON.md
@@ -187,7 +187,7 @@ Here is a complete list of the configuration options you can set to customize yo
 * `:fmt [format]`     Set output formatter (default: `{:?}`). 
 * `:efmt [format]`    Set the formatter for errors returned by `?`
 * `:sccache [0|1]`    Set whether to use sccache.
-* `:linker [linker]`  Set/print linker. Supported: `system`, `lld`
+* `:linker [linker]`  Set/print linker. Supported: `system`, `lld`, `mold`
 * `:timing`           Toggle printing of how long evaluations take
 * `:time_passes`      Toggle printing of rustc pass times (requires nightly)
 * `:internal_debug`   Toggle internal code debugging output

--- a/evcxr/src/command_context.rs
+++ b/evcxr/src/command_context.rs
@@ -489,7 +489,7 @@ Panic detected. Here's some useful information if you're filing a bug report.
             ),
             AvailableCommand::new(
                 ":linker",
-                "Set/print linker. Supported: system, lld",
+                "Set/print linker. Supported: system, lld, mold",
                 |_ctx, state, args| {
                     if let Some(linker) = args {
                         state.set_linker(linker.to_owned());

--- a/evcxr/src/eval_context.rs
+++ b/evcxr/src/eval_context.rs
@@ -34,6 +34,7 @@ use ra_ap_syntax::{ast, AstNode, SyntaxKind, SyntaxNode};
 use regex::Regex;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
@@ -121,8 +122,15 @@ impl Config {
         self.sccache.is_some()
     }
 
-    pub(crate) fn cargo_command(&self, command_name: &str) -> std::process::Command {
-        let mut command = std::process::Command::new("cargo");
+    pub(crate) fn cargo_command(&self, command_name: &str) -> Command {
+        let mut command = if self.linker == "mold" {
+            Command::new("mold")
+        } else {
+            Command::new("cargo")
+        };
+        if self.linker == "mold" {
+            command.arg("-run").arg("cargo");
+        }
         if !self.toolchain.is_empty() {
             command.arg(format!("+{}", self.toolchain));
         }

--- a/evcxr/src/eval_context.rs
+++ b/evcxr/src/eval_context.rs
@@ -80,7 +80,12 @@ pub(crate) struct Config {
 
 fn create_initial_config(crate_dir: PathBuf) -> Config {
     let mut config = Config::new(crate_dir);
-    if !cfg!(target_os = "macos") && which::which("lld").is_ok() {
+    // default the linker to mold, then lld, first checking if either are installed
+    // neither linkers support macos, so fallback to system (aka default)
+    // https://github.com/rui314/mold/issues/132
+    if !cfg!(target_os = "macos") && which::which("mold").is_ok() {
+        config.linker = "mold".to_owned();
+    } else if !cfg!(target_os = "macos") && which::which("lld").is_ok() {
         config.linker = "lld".to_owned();
     }
     config

--- a/evcxr/src/module.rs
+++ b/evcxr/src/module.rs
@@ -163,7 +163,7 @@ impl Module {
             .arg("-C")
             .arg("prefer-dynamic")
             .env("CARGO_TARGET_DIR", "target");
-        if config.linker != "system" {
+        if config.linker == "lld" {
             command
                 .arg("-C")
                 .arg(format!("link-arg=-fuse-ld={}", config.linker));


### PR DESCRIPTION
This patch adds support for using `mold` as the linker for `evcxr` by injecting it in-front of the `cargo` compile commands (if configured), the rationale for that is discussed here in: https://github.com/rui314/mold#how-to-use

Tested mostly locally in JupyterLab and seems to work for me, let me know if I'm missing anything!

EDIT: Extracting the mold `.comment` from the generated binary: 
```sh
.tmpVO1W2R/target/debug 
❯ readelf -p .comment libctx.so 

String dump of section '.comment':
  [     0]  GCC: (GNU) 11.2.1 20211203 (Red Hat 11.2.1-7)
  [    2e]  mold 1.0.0 (ed9924895d9b9584106791247596677db8113528; compatible with GNU ld and GNU gold)

```