### PR TITLE
Escape ampersand

### DIFF
--- a/evcxr/src/command_context.rs
+++ b/evcxr/src/command_context.rs
@@ -656,6 +656,7 @@ impl AvailableCommand {
 fn html_escape(input: &str, out: &mut String) {
     for ch in input.chars() {
         match ch {
+            '&' => out.push_str("&amp;"),
             '<' => out.push_str("&lt;"),
             '>' => out.push_str("&gt;"),
             x => out.push(x),


### PR DESCRIPTION
A stray ampersand can cause HTML validation errors. Most browsers are quite tolerant, but it pays to be conservative.

Re-submission of #208 