### PR TITLE
Added support for line comments between :deps

### DIFF
--- a/evcxr/src/code_block.rs
+++ b/evcxr/src/code_block.rs
@@ -214,10 +214,9 @@ impl CodeBlock {
                     }),
                     line,
                 );
-            } else if line.trim().is_empty() {
+            } else if line.starts_with(r"//") || line.trim().is_empty() {
                 // Ignore blank lines, otherwise we can't have blank lines before :dep commands.
-            } else if line.starts_with(r"//") {
-                // Ignore comments
+                // We also ignore lines that start with //, because those are line comments.
             } else {
                 // Anything else, we treat as Rust code to be executed. Since we don't accept commands after Rust code, we're done looking for commands.
                 let non_command_start_byte = line.as_ptr() as usize - user_code.as_ptr() as usize;

--- a/evcxr/src/code_block.rs
+++ b/evcxr/src/code_block.rs
@@ -216,6 +216,8 @@ impl CodeBlock {
                 );
             } else if line.trim().is_empty() {
                 // Ignore blank lines, otherwise we can't have blank lines before :dep commands.
+            } else if line.starts_with(r"//") {
+                // Ignore comments
             } else {
                 // Anything else, we treat as Rust code to be executed. Since we don't accept commands after Rust code, we're done looking for commands.
                 let non_command_start_byte = line.as_ptr() as usize - user_code.as_ptr() as usize;

--- a/evcxr/tests/integration_tests.rs
+++ b/evcxr/tests/integration_tests.rs
@@ -991,10 +991,11 @@ let s2 = "さび  äää"; let s2: String = 42; fn foo() -> i32 {
             "\
             :dep this_crate_does_not_exist = \"12.34\"\n\
             :dep foo = { path = \"/this/path/does/not/exist\" }\n\
+            // This is a comment interleaved with commands\n\
             :an_invalid_command
             "
         )),
-        vec!["error 1:6-1:41", "error 2:6-2:50", "error 3:1-3:20"]
+        vec!["error 1:6-1:41", "error 2:6-2:50", "error 4:1-4:20"]
     );
 
     // Make sure missing close parenthesis are reported as expected. Note, we still don't check the


### PR DESCRIPTION
Now line comments don't "break" [the loop](https://github.com/google/evcxr/blob/main/evcxr/src/code_block.rs#L205-L251) in `CodeBlock::from_original_user_code`.

Augmented one of the integration tests with a line comment interleaving the commands like `:dep`.