### PR TITLE
Use ariadne for rendering diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,6 +615,7 @@ dependencies = [
  "structopt",
  "unicode-segmentation",
  "unicode-xid",
+ "yansi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1f8f5a6f3d50d89e3797d7593a50f96bb2aaa20ca0cc7be1fb673232c91d72"
 
 [[package]]
+name = "ariadne"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1cb2a2046bea8ce5e875551f5772024882de0b540c7f93dfc5d6cf1ca8b030c"
+dependencies = [
+ "yansi",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,6 +603,7 @@ dependencies = [
 name = "evcxr_repl"
 version = "0.13.0"
 dependencies = [
+ "ariadne",
  "colored",
  "crossbeam-channel",
  "evcxr",
@@ -2458,6 +2468,12 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zeromq-src"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,6 +538,7 @@ name = "evcxr"
 version = "0.13.0"
 dependencies = [
  "anyhow",
+ "ariadne",
  "backtrace",
  "crossbeam-channel",
  "dirs",
@@ -583,6 +584,7 @@ name = "evcxr_jupyter"
 version = "0.13.0"
 dependencies = [
  "anyhow",
+ "ariadne",
  "chrono",
  "colored",
  "crossbeam-channel",

--- a/evcxr/Cargo.toml
+++ b/evcxr/Cargo.toml
@@ -38,6 +38,7 @@ ra_ap_syntax = "=0.0.120"
 # semver bump. So we pin salsa to an exact version and update as needed together with the ra_ap_*
 # packages.
 salsa = "=0.17.0-pre.2"
+ariadne = "0.1.5"
 
 [target.'cfg(all(unix, not(target_os = "freebsd")))'.dependencies]
 sig = "1.0.0"

--- a/evcxr/src/errors.rs
+++ b/evcxr/src/errors.rs
@@ -63,27 +63,22 @@ fn get_code_origins_for_span<'a>(
                 code_origins.push(code_block.origin_for_line(line));
             }
         }
-        let mut bs = span["byte_start"].as_usize().unwrap_or(0) + 20;
-        let mut be = span["byte_end"].as_usize().unwrap_or(0) + 20;
-        for x in &code_block.segments {
-            if x.code.len() > bs {
-                break;
+        let find_pos = |mut pos| {
+            let mut result = pos;
+            for x in &code_block.segments {
+                if x.code.len() > pos {
+                    break;
+                }
+                pos -= x.code.len();
+                if !matches!(x.kind, CodeKind::OriginalUserCode(_)) {
+                    result -= x.code.len();
+                }
             }
-            if matches!(x.kind, CodeKind::OriginalUserCode(_)) {
-                break;
-            }
-            bs -= x.code.len();
-        }
-        for x in &code_block.segments {
-            if x.code.len() > be {
-                break;
-            }
-            if matches!(x.kind, CodeKind::OriginalUserCode(_)) {
-                break;
-            }
-            be -= x.code.len();
-        }
-        (code_origins, (bs, be))
+            result
+        };
+        let result_start = find_pos(span["byte_start"].as_usize().unwrap_or(0));
+        let result_end = find_pos(span["byte_end"].as_usize().unwrap_or(0));
+        (code_origins, (result_start, result_end))
     } else {
         (vec![], (0, 0))
     }

--- a/evcxr/src/lib.rs
+++ b/evcxr/src/lib.rs
@@ -35,7 +35,7 @@ mod statement_splitter;
 mod use_trees;
 
 pub use crate::command_context::CommandContext;
-pub use crate::errors::CompilationError;
+pub use crate::errors::{CompilationError, Theme};
 pub use crate::errors::Error;
 pub use crate::eval_context::EvalCallbacks;
 pub use crate::eval_context::EvalContext;

--- a/evcxr/src/lib.rs
+++ b/evcxr/src/lib.rs
@@ -35,8 +35,8 @@ mod statement_splitter;
 mod use_trees;
 
 pub use crate::command_context::CommandContext;
-pub use crate::errors::{CompilationError, Theme};
 pub use crate::errors::Error;
+pub use crate::errors::{CompilationError, Theme};
 pub use crate::eval_context::EvalCallbacks;
 pub use crate::eval_context::EvalContext;
 pub use crate::eval_context::EvalContextOutputs;

--- a/evcxr_jupyter/Cargo.toml
+++ b/evcxr_jupyter/Cargo.toml
@@ -25,6 +25,7 @@ unicode-segmentation = "1.7.1"
 generic-array = "0.14.4"
 mimalloc = { version = "0.1", default-features = false, optional = true }
 crossbeam-channel = "0.5.5"
+ariadne = "0.1.5"
 
 [features]
 default = ["vendored-zmq", "mimalloc"]

--- a/evcxr_jupyter/src/core.rs
+++ b/evcxr_jupyter/src/core.rs
@@ -21,6 +21,7 @@ use ariadne::sources;
 use colored::*;
 use crossbeam_channel::Select;
 use evcxr::CommandContext;
+use evcxr::Theme;
 use json::JsonValue;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -432,7 +433,7 @@ impl Server {
                     let message = format!("{}", error.message().bright_red());
                     if error.is_from_user_code() {
                         let mut traceback = Vec::new();
-                        if let Some(report) = error.build_report(&self.command_history) {
+                        if let Some(report) = error.build_report(&self.command_history, Theme::Light) {
                             let mut s = Vec::new();
                             report
                                 .write(sources(self.command_history.clone().into_iter()), &mut s)

--- a/evcxr_repl/Cargo.toml
+++ b/evcxr_repl/Cargo.toml
@@ -24,3 +24,4 @@ mimalloc = { version = "0.1", default-features = false, optional = true }
 parking_lot = "0.12.1"
 crossbeam-channel = "0.5.5"
 ariadne = "0.1.5"
+yansi = "0.5.1"

--- a/evcxr_repl/Cargo.toml
+++ b/evcxr_repl/Cargo.toml
@@ -23,3 +23,4 @@ unicode-segmentation = "1.7.1"
 mimalloc = { version = "0.1", default-features = false, optional = true }
 parking_lot = "0.12.1"
 crossbeam-channel = "0.5.5"
+ariadne = "0.1.5"

--- a/evcxr_repl/src/bin/evcxr.rs
+++ b/evcxr_repl/src/bin/evcxr.rs
@@ -17,6 +17,7 @@ use colored::*;
 use evcxr::CommandContext;
 use evcxr::CompilationError;
 use evcxr::Error;
+use evcxr::Theme;
 use evcxr_repl::BgInitMutex;
 use evcxr_repl::EvcxrRustylineHelper;
 use rustyline::error::ReadlineError;
@@ -135,7 +136,7 @@ impl Repl {
         let mut last_span_lines: &Vec<String> = &vec![];
         for error in &errors {
             if error.is_from_user_code() {
-                if let Some(report) = error.build_report(&self.command_history) {
+                if let Some(report) = error.build_report(&self.command_history, Theme::Dark) {
                     report
                         .print(sources(self.command_history.clone().into_iter()))
                         .unwrap();


### PR DESCRIPTION
Before:

In REPL:
![image](https://user-images.githubusercontent.com/45197576/184141225-11593bcb-1eae-4533-9cd6-f821a54dcbd3.png)

in jupyter notebook:
![image](https://user-images.githubusercontent.com/45197576/184141874-9c79c7dc-ecf6-4769-9e6c-d231bc240a27.png)

After:

in REPL:
![image](https://user-images.githubusercontent.com/45197576/184142062-90136f87-55e6-4fd5-b3f5-22e0eb2afab4.png)

I didn't managed to make it working in jupyter notebook.

This PR is just a proof of concept, for giving feedback. It doesn't actually work for anything other than my example (I added a `+20` offset for spans somewhere to make it working) and it should show helps and notes using ariadne as well (the currently rendered help is from old code). [Ariadne has a very easy to use api](https://github.com/zesterer/ariadne/tree/main/examples), it gets a list of files with their sources (commands and cells in our use case) and a list of spans (declared with byte ranges) with messages and colors, then it will automatically render everything in the right place. So someone that know more than me (= more than nothing) about `evcxr` can do it the right way fairly easily. But I can also make it with some mentoring if needed.

Rust is famous for its great compile messages. Lets make them great in `evcxr` as well!