### PR TITLE
updating inconsistency in custom output description (different from c…

### DIFF
--- a/evcxr_jupyter/README.md
+++ b/evcxr_jupyter/README.md
@@ -92,7 +92,7 @@ formatter to emit plain text. If you'd like, you can provide a function to show
 your type (or someone else's type) as HTML (or an image). To do this, the type
 needs to implement a method called ```evcxr_display``` which should then print
 one or more mime-typed blocks to stdout. Each block starts with a line
-containing BEGIN\_EVCXR\_OUTPUT followed by the mime type, then a newline, the
+containing EVCXR\_BEGIN\_CONTENT followed by the mime type, then a newline, the
 content then ends with a line containing EVCXR\_END\_CONTENT.
 
 For example, the following shows how you might provide a custom display function for a


### PR DESCRIPTION
From file: evcxr_jupyter/README.md 
Section: Custom output

last sentence in the 1st paragraph:
```
Each block starts with a line containing BEGIN_EVCXR_OUTPUT followed by the mime type, then a newline, the content then ends with a line containing EVCXR_END_CONTENT.
```

So it says block starts with BEGIN\_EVCXR\_OUTPUT, and from the code example below, it should be EVCXR\_BEGIN\_CONTENT

I haven't tested whether BEGIN_EVCXR_OUTPUT will do the work, but there's an inconsistency between the description and the example and I think it should be fixed.