### PR TITLE
Add a command that displays the type of outputs

### DIFF
--- a/COMMON.md
+++ b/COMMON.md
@@ -182,6 +182,7 @@ Here is a complete list of the configuration options you can set to customize yo
 
 * `:opt [level]`      Toggle/set optimization level
 * `:fmt [format]`     Set output formatter (default: `{:?}`). 
+* `:t`                Toggle printing of the type of the output
 * `:efmt [format]`    Set the formatter for errors returned by `?`
 * `:sccache [0|1]`    Set whether to use sccache.
 * `:linker [linker]`  Set/print linker. Supported: `system`, `lld`, `mold`

--- a/COMMON.md
+++ b/COMMON.md
@@ -182,7 +182,7 @@ Here is a complete list of the configuration options you can set to customize yo
 
 * `:opt [level]`      Toggle/set optimization level
 * `:fmt [format]`     Set output formatter (default: `{:?}`). 
-* `:t`                Toggle printing of the type of the output
+* `:types`            Toggle printing of the type of the output
 * `:efmt [format]`    Set the formatter for errors returned by `?`
 * `:sccache [0|1]`    Set whether to use sccache.
 * `:linker [linker]`  Set/print linker. Supported: `system`, `lld`, `mold`

--- a/evcxr/src/command_context.rs
+++ b/evcxr/src/command_context.rs
@@ -437,11 +437,11 @@ Panic detected. Here's some useful information if you're filing a bug report.
                 },
             ),
             AvailableCommand::new(
-                ":t",
+                ":types",
                 "Toggle printing of types",
                 |_ctx, state, _args| {
-                    state.set_display_type(!state.display_type());
-                    text_output(format!("Types: {}", state.display_type()))
+                    state.set_display_types(!state.display_types());
+                    text_output(format!("Types: {}", state.display_types()))
                 },
             ),
             AvailableCommand::new(

--- a/evcxr/src/command_context.rs
+++ b/evcxr/src/command_context.rs
@@ -437,6 +437,14 @@ Panic detected. Here's some useful information if you're filing a bug report.
                 },
             ),
             AvailableCommand::new(
+                ":t",
+                "Toggle printing of types",
+                |_ctx, state, _args| {
+                    state.set_display_type(!state.display_type());
+                    text_output(format!("Types: {}", state.display_type()))
+                },
+            ),
+            AvailableCommand::new(
                 ":efmt",
                 "Set the formatter for errors returned by ?",
                 |_ctx, state, args| {

--- a/evcxr/src/eval_context.rs
+++ b/evcxr/src/eval_context.rs
@@ -215,7 +215,7 @@ const SEND_TEXT_PLAIN_DEF: &str = stringify!(
         let mut buf = String::new();
         // The position after the last "::" in buf - upon a successful match, only what's
         // after that should be used.
-        let mut pos_after_last_double_colon : Option<usize> = None;
+        let mut pos_after_last_double_colon: Option<usize> = None;
 
         for c in t.chars() {
             let mut match_ended = false;
@@ -265,7 +265,7 @@ const SEND_TEXT_PLAIN_DEF: &str = stringify!(
         }
         r
     }
-    
+
     fn evcxr_get_type_name<T>(_: &T) -> String {
         evcxr_shorten_type(std::any::type_name::<T>())
         //std::any::type_name::<T>().to_string()

--- a/evcxr/src/eval_context.rs
+++ b/evcxr/src/eval_context.rs
@@ -71,7 +71,7 @@ pub(crate) struct Config {
     // attempt to determine if the type of the variable is copy.
     preserve_vars_on_panic: bool,
     output_format: String,
-    display_type: bool,
+    display_types: bool,
     /// Whether to try to display the final expression. Currently this needs to
     /// be turned off when doing tab completion or cargo check, but otherwise it
     /// should always be on.
@@ -114,7 +114,7 @@ impl Config {
             debug_mode: false,
             preserve_vars_on_panic: true,
             output_format: "{:?}".to_owned(),
-            display_type: false,
+            display_types: false,
             display_final_expression: true,
             expand_use_statements: true,
             opt_level: "2".to_owned(),
@@ -205,70 +205,34 @@ const SEND_TEXT_PLAIN_DEF: &str = stringify!(
             std::process::exit(1);
         }
     }
+);
 
-    /// Shorten a type name. Convert "core::option::Option::<alloc::string::String>" into "Option<String>".
+const GET_TYPE_NAME_DEF: &str = stringify!(
+    /// Shorten a type name. Convert "core::option::Option<alloc::string::String>" into "Option<String>".
     pub fn evcxr_shorten_type(t: &str) -> String {
         // This could have been done easily with regex, but we must only depend on stdlib.
-        let mut r = String::new();
-        // buf holds the chars that may be a part of a long identifier.
-        // This is a string like: "ID1::ID2:"
-        let mut buf = String::new();
-        // The position after the last "::" in buf - upon a successful match, only what's
-        // after that should be used.
-        let mut pos_after_last_double_colon: Option<usize> = None;
-
-        for c in t.chars() {
-            let mut match_ended = false;
-            if buf.len() == 0 || pos_after_last_double_colon == Some(buf.len()) {
-                // Expecting the start of an identified
-                if c.is_alphabetic() || c == '_' {
-                    buf.push(c);
-                } else {
-                    match_ended = true;
-                }
-            } else if buf.chars().last().unwrap() == ':' {
-                // After a ':', we must have another ':'.
+        // We go over the string backwards, and remove all alphanumeric and ':' chars following a ':'.
+        let mut r = String::with_capacity(t.len());
+        let mut is_skipping = false;
+        for c in t.chars().rev() {
+            if !is_skipping {
                 if c == ':' {
-                    buf.push(c);
-                    pos_after_last_double_colon = Some(buf.len());
+                    is_skipping = true;
                 } else {
-                    match_ended = true;
-                }
-            } else if c == ':' {
-                if buf.len() != 0 {
-                    buf.push(c);
-                } else {
-                    match_ended = true;
+                    r.push(c);
                 }
             } else {
-                if c.is_alphanumeric() || c == '_' {
-                    buf.push(c);
-                } else {
-                    match_ended = true;
+                if !c.is_alphanumeric() && c != '_' && c != ':' {
+                    is_skipping = false;
+                    r.push(c);
                 }
             }
-            if match_ended {
-                if pos_after_last_double_colon.is_some() && buf.chars().last() != Some(':') {
-                    r.push_str(&buf[pos_after_last_double_colon.unwrap()..]);
-                } else {
-                    r.push_str(&buf);
-                }
-                buf.clear();
-                pos_after_last_double_colon = None;
-                r.push(c);
-            }
         }
-        if pos_after_last_double_colon.is_some() && buf.chars().last() != Some(':') {
-            r.push_str(&buf[pos_after_last_double_colon.unwrap()..]);
-        } else {
-            r.push_str(&buf);
-        }
-        r
+        r.chars().rev().collect()
     }
 
     fn evcxr_get_type_name<T>(_: &T) -> String {
         evcxr_shorten_type(std::any::type_name::<T>())
-        //std::any::type_name::<T>().to_string()
     }
 );
 
@@ -1210,12 +1174,12 @@ impl ContextState {
         self.config.output_format = output_format;
     }
 
-    pub fn display_type(&self) -> bool {
-        self.config.display_type
+    pub fn display_types(&self) -> bool {
+        self.config.display_types
     }
 
-    pub fn set_display_type(&mut self, display_type: bool) {
-        self.config.display_type = display_type;
+    pub fn set_display_types(&mut self, display_types: bool) {
+        self.config.display_types = display_types;
     }
 
     pub fn set_toolchain(&mut self, value: &str) {
@@ -1653,9 +1617,10 @@ impl ContextState {
                                 .generated(").evcxr_display();")
                                 .code_string(),
                             // If that fails, we try debug format.
-                            if self.config.display_type {
+                            if self.config.display_types {
                                 CodeBlock::new()
                                 .generated(SEND_TEXT_PLAIN_DEF)
+                                .generated(GET_TYPE_NAME_DEF)
                                 .generated("{ let r = &(")
                                 .with_segment(segment)
                                 .generated(format!(

--- a/evcxr/tests/integration_tests.rs
+++ b/evcxr/tests/integration_tests.rs
@@ -691,7 +691,11 @@ fn print_then_assign_variable() {
 fn display_type() {
     let mut e = new_context();
     assert_eq!(
-        e.execute(":t").unwrap().get("text/plain").unwrap().trim(),
+        e.execute(":types")
+            .unwrap()
+            .get("text/plain")
+            .unwrap()
+            .trim(),
         "Types: true"
     );
     assert_eq!(eval!(e, 42), text_plain(": i32 = 42"));
@@ -700,7 +704,11 @@ fn display_type() {
         text_plain(": Option<String> = Some(\"hello\")")
     );
     assert_eq!(
-        e.execute(":t").unwrap().get("text/plain").unwrap().trim(),
+        e.execute(":types")
+            .unwrap()
+            .get("text/plain")
+            .unwrap()
+            .trim(),
         "Types: false"
     );
     assert_eq!(eval!(e, 42), text_plain("42"));
@@ -711,30 +719,23 @@ fn shorten_type_name() {
     // This is a way to test the evcxr_shorten_type() function, evaluated in the child
     let mut e = new_context();
     e.execute(":fmt {}").unwrap();
+    // We need to enable types, so evcxr_shorten_type() will be defined.
+    e.execute(":types").unwrap();
     assert_eq!(
         eval!(e, evcxr_shorten_type("alloc::string::String")),
-        text_plain("String")
+        text_plain(": String = String")
     );
     assert_eq!(
         eval!(
             e,
             evcxr_shorten_type("core::option::Option<alloc::string::String>")
         ),
-        text_plain("Option<String>")
+        text_plain(": String = Option<String>")
     );
     assert_eq!(
-        eval!(e, evcxr_shorten_type("c::o::O::<a::s::S>")),
-        text_plain("c::o::O::<S>")
+        eval!(e, evcxr_shorten_type("i32")),
+        text_plain(": String = i32")
     );
-    assert_eq!(
-        eval!(e, evcxr_shorten_type("c::o::O<a::s::S::>")),
-        text_plain("O<a::s::S::>")
-    );
-    assert_eq!(
-        eval!(e, evcxr_shorten_type("core::3x")),
-        text_plain("core::3x")
-    );
-    assert_eq!(eval!(e, evcxr_shorten_type("i32")), text_plain("i32"));
 }
 
 #[test]

--- a/evcxr/tests/integration_tests.rs
+++ b/evcxr/tests/integration_tests.rs
@@ -688,6 +688,29 @@ fn print_then_assign_variable() {
 }
 
 #[test]
+fn display_type() {
+    let mut e = new_context();
+    assert_eq!(e.execute(":t").unwrap().get("text/plain").unwrap().trim(), "Types: true");
+    assert_eq!(eval!(e, 42), text_plain(": i32 = 42"));
+    assert_eq!(eval!(e, Some("hello".to_string())), text_plain(": Option<String> = Some(\"hello\")"));
+    assert_eq!(e.execute(":t").unwrap().get("text/plain").unwrap().trim(), "Types: false");
+    assert_eq!(eval!(e, 42), text_plain("42"));
+}
+
+#[test]
+fn shorten_type_name() {
+    // This is a way to test the evcxr_shorten_type() function, evaluated in the child
+    let mut e = new_context();
+    e.execute(":fmt {}").unwrap();
+    assert_eq!(eval!(e, evcxr_shorten_type("alloc::string::String")), text_plain("String"));
+    assert_eq!(eval!(e, evcxr_shorten_type("core::option::Option<alloc::string::String>")), text_plain("Option<String>"));
+    assert_eq!(eval!(e, evcxr_shorten_type("c::o::O::<a::s::S>")), text_plain("c::o::O::<S>"));
+    assert_eq!(eval!(e, evcxr_shorten_type("c::o::O<a::s::S::>")), text_plain("O<a::s::S::>"));
+    assert_eq!(eval!(e, evcxr_shorten_type("core::3x")), text_plain("core::3x"));
+    assert_eq!(eval!(e, evcxr_shorten_type("i32")), text_plain("i32"));
+}
+
+#[test]
 fn question_mark_operator() {
     let mut e = new_context();
     // Make sure question mark works without variables.

--- a/evcxr/tests/integration_tests.rs
+++ b/evcxr/tests/integration_tests.rs
@@ -690,10 +690,19 @@ fn print_then_assign_variable() {
 #[test]
 fn display_type() {
     let mut e = new_context();
-    assert_eq!(e.execute(":t").unwrap().get("text/plain").unwrap().trim(), "Types: true");
+    assert_eq!(
+        e.execute(":t").unwrap().get("text/plain").unwrap().trim(),
+        "Types: true"
+    );
     assert_eq!(eval!(e, 42), text_plain(": i32 = 42"));
-    assert_eq!(eval!(e, Some("hello".to_string())), text_plain(": Option<String> = Some(\"hello\")"));
-    assert_eq!(e.execute(":t").unwrap().get("text/plain").unwrap().trim(), "Types: false");
+    assert_eq!(
+        eval!(e, Some("hello".to_string())),
+        text_plain(": Option<String> = Some(\"hello\")")
+    );
+    assert_eq!(
+        e.execute(":t").unwrap().get("text/plain").unwrap().trim(),
+        "Types: false"
+    );
     assert_eq!(eval!(e, 42), text_plain("42"));
 }
 
@@ -702,11 +711,29 @@ fn shorten_type_name() {
     // This is a way to test the evcxr_shorten_type() function, evaluated in the child
     let mut e = new_context();
     e.execute(":fmt {}").unwrap();
-    assert_eq!(eval!(e, evcxr_shorten_type("alloc::string::String")), text_plain("String"));
-    assert_eq!(eval!(e, evcxr_shorten_type("core::option::Option<alloc::string::String>")), text_plain("Option<String>"));
-    assert_eq!(eval!(e, evcxr_shorten_type("c::o::O::<a::s::S>")), text_plain("c::o::O::<S>"));
-    assert_eq!(eval!(e, evcxr_shorten_type("c::o::O<a::s::S::>")), text_plain("O<a::s::S::>"));
-    assert_eq!(eval!(e, evcxr_shorten_type("core::3x")), text_plain("core::3x"));
+    assert_eq!(
+        eval!(e, evcxr_shorten_type("alloc::string::String")),
+        text_plain("String")
+    );
+    assert_eq!(
+        eval!(
+            e,
+            evcxr_shorten_type("core::option::Option<alloc::string::String>")
+        ),
+        text_plain("Option<String>")
+    );
+    assert_eq!(
+        eval!(e, evcxr_shorten_type("c::o::O::<a::s::S>")),
+        text_plain("c::o::O::<S>")
+    );
+    assert_eq!(
+        eval!(e, evcxr_shorten_type("c::o::O<a::s::S::>")),
+        text_plain("O<a::s::S::>")
+    );
+    assert_eq!(
+        eval!(e, evcxr_shorten_type("core::3x")),
+        text_plain("core::3x")
+    );
     assert_eq!(eval!(e, evcxr_shorten_type("i32")), text_plain("i32"));
 }
 


### PR DESCRIPTION
I find it very useful to see the type of expressions. So I tried to add this feature to evcxr. What I did works like this:

```
>> :t
Types: true

>> 3 + 5
: i32 = 8
>> "hello"
: &str = "hello"
>> Some("hello".to_string())
: Option<String> = Some("hello")
>> vec![1, 2, 3]
: Vec<i32> = [1, 2, 3]
```

To get the type names I used `std::any::type_name()`, and added a function which only leaves the last part of paths, so it converts `core::option::Option<alloc::string::String>` into `Option<String>`, which is much easier on the eyes.

Things which I chose arbitrarily and should be decided:

* The name of the command (`:t`)
* The format (I used `: <type> = <repr>`)

A note: for shortening the name I pushed a function (`evcxr_shorten_type`) into the child. It's quite long, and has some intricate logic, because it had to be written without relying on regex. I think it would be better to send the raw type string along with the value, and shorten it at the main process using regex. If the concept is approved, I would be happy to try it. For now, it was simpler for me to avoid changing the interface between the processes and instead add the string on the child side.

What do you think?

Thanks,
Noam